### PR TITLE
Changes To Fix Rerouting on TLS Encrypted Connections  

### DIFF
--- a/test/integration/connection-test.coffee
+++ b/test/integration/connection-test.coffee
@@ -207,6 +207,10 @@ exports.encrypt = (test) ->
     test.done()
   )
 
+  connection.on('rerouting', (info) ->
+    test.expect(8)
+  )
+
   connection.on('databaseChange', (database) ->
     test.strictEqual(database, config.options.database)
   )


### PR DESCRIPTION
Needed to make the following changes to support (in connection.coffee unless otherwise stated)
- New event needed for rerouting called as such "rerouting"
- Replaced previous "end" event on rerouting with aforementioned new event, "rerouting"
- Initialize tlsNegotiationComplete as false on start of SENT_TLSSSLNEGOTIATION
- Add server to serverName property in Login7Packet in the event the servername differs from the redirected hostname address (eg connect to serverA.net -> redirected to serverB.net -> server at serverB.net expects serverA's name for the server)
- Fixed up the integration/connection-test.coffee test to account for redirection on an encrypted server requiring 2 separate "encrypt" events, resulting in 3 additional successes in addition to the original expectation of 5 success

Changes not included in this commit
- Need to update the Connection api webpage to document the new rerouting event