### PR TITLE
[WIP] Stream based token parser

### DIFF
--- a/benchmarks/benchmarks.coffee
+++ b/benchmarks/benchmarks.coffee
@@ -46,7 +46,7 @@ module.exports =
         return cb(err) if err
 
         request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-        request.addParameter("value", TYPES.VarBinary, "asdf")
+        request.addParameter("value", TYPES.VarBinary, new Buffer("asdf"))
         connection.execSql(request)
 
       connection.execSqlBatch(request)
@@ -65,7 +65,7 @@ module.exports =
         return cb(err) if err
 
         request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-        request.addParameter("value", TYPES.VarBinary, "asdf")
+        request.addParameter("value", TYPES.VarBinary, new Buffer("asdf"))
         connection.execSql(request)
 
       connection.execSqlBatch(request)
@@ -89,7 +89,9 @@ module.exports =
         return cb(err) if err
 
         request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-        request.addParameter("value", TYPES.VarBinary, new Array(5 * 1024 * 1024).join("x"))
+        buf = new Buffer(5 * 1024 * 1024)
+        buf.fill("x")
+        request.addParameter("value", TYPES.VarBinary, buf)
         connection.execSql(request)
 
       connection.execSqlBatch(request)
@@ -108,7 +110,9 @@ module.exports =
         return cb(err) if err
 
         request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-        request.addParameter("value", TYPES.VarBinary, new Array(50 * 1024 * 1024).join("x"))
+        buf = new Buffer(50 * 1024 * 1024)
+        buf.fill("x")
+        request.addParameter("value", TYPES.VarBinary, buf)
         connection.execSql(request)
 
       connection.execSqlBatch(request)

--- a/benchmarks/benchmarks.coffee
+++ b/benchmarks/benchmarks.coffee
@@ -2,81 +2,105 @@
 
 module.exports =
 
-#  "nvarchar (small)":
-#    setup: (connection, cb) ->
-#      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
-#        return cb(err) if err
-#
-#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-#        request.addParameter("value", TYPES.NVarChar, "asdf")
-#        connection.execSql(request)
-#
-#      connection.execSqlBatch(request)
-#
-#    exec: (connection, cb) ->
-#      request = new Request "SELECT * FROM #benchmark", cb
-#      connection.execSql(request)
-#
-#    teardown: (connection, cb) ->
-#      request = new Request "DROP TABLE #benchmark", cb
-#      connection.execSqlBatch(request)
-#
-#  "nvarchar (large)":
-#    setup: (connection, cb) ->
-#      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
-#        return cb(err) if err
-#
-#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-#        request.addParameter("value", TYPES.NVarChar, new Array(5 * 1024 * 1024).join("x"))
-#        connection.execSql(request)
-#
-#      connection.execSqlBatch(request)
-#
-#    exec: (connection, cb) ->
-#      request = new Request "SELECT * FROM #benchmark", cb
-#      connection.execSql(request)
-#
-#    teardown: (connection, cb) ->
-#      request = new Request "DROP TABLE #benchmark", cb
-#      connection.execSqlBatch(request)
-#
-#  "varbinary (small)":
-#    setup: (connection, cb) ->
-#      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
-#        return cb(err) if err
-#
-#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-#        request.addParameter("value", TYPES.VarBinary, "asdf")
-#        connection.execSql(request)
-#
-#      connection.execSqlBatch(request)
-#
-#    exec: (connection, cb) ->
-#      request = new Request "SELECT * FROM #benchmark", cb
-#      connection.execSql(request)
-#
-#    teardown: (connection, cb) ->
-#      request = new Request "DROP TABLE #benchmark", cb
-#      connection.execSqlBatch(request)
-#
-#  "varbinary (large)":
-#    setup: (connection, cb) ->
-#      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
-#        return cb(err) if err
-#
-#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
-#        request.addParameter("value", TYPES.VarBinary, new Array(5 * 1024 * 1024).join("x"))
-#        connection.execSql(request)
-#
-#      connection.execSqlBatch(request)
-#
-#    exec: (connection, cb) ->
-#      request = new Request "SELECT * FROM #benchmark", cb
-#      connection.execSql(request)
-#
-#    teardown: (connection, cb) ->
-#      request = new Request "DROP TABLE #benchmark", cb
-#      connection.execSqlBatch(request)
+  "nvarchar (small)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.NVarChar, "asdf")
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+  "nvarchar (large)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.NVarChar, new Array(5 * 1024 * 1024).join("x"))
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+  "varbinary (small)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.VarBinary, "asdf")
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+  "varbinary (4)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(4))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.VarBinary, "asdf")
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", (err) ->
+        console.log(arguments)
+        cb()
+      request.on "row", (data) ->
+        console.log(data[0].value.toString())
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+
+  "varbinary (large)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.VarBinary, new Array(5 * 1024 * 1024).join("x"))
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
 
   "varbinary (huge)":
     setup: (connection, cb) ->

--- a/benchmarks/benchmarks.coffee
+++ b/benchmarks/benchmarks.coffee
@@ -1,0 +1,98 @@
+{Request, TYPES} = require "../src/tedious"
+
+module.exports =
+
+#  "nvarchar (small)":
+#    setup: (connection, cb) ->
+#      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
+#        return cb(err) if err
+#
+#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+#        request.addParameter("value", TYPES.NVarChar, "asdf")
+#        connection.execSql(request)
+#
+#      connection.execSqlBatch(request)
+#
+#    exec: (connection, cb) ->
+#      request = new Request "SELECT * FROM #benchmark", cb
+#      connection.execSql(request)
+#
+#    teardown: (connection, cb) ->
+#      request = new Request "DROP TABLE #benchmark", cb
+#      connection.execSqlBatch(request)
+#
+#  "nvarchar (large)":
+#    setup: (connection, cb) ->
+#      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
+#        return cb(err) if err
+#
+#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+#        request.addParameter("value", TYPES.NVarChar, new Array(5 * 1024 * 1024).join("x"))
+#        connection.execSql(request)
+#
+#      connection.execSqlBatch(request)
+#
+#    exec: (connection, cb) ->
+#      request = new Request "SELECT * FROM #benchmark", cb
+#      connection.execSql(request)
+#
+#    teardown: (connection, cb) ->
+#      request = new Request "DROP TABLE #benchmark", cb
+#      connection.execSqlBatch(request)
+#
+#  "varbinary (small)":
+#    setup: (connection, cb) ->
+#      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+#        return cb(err) if err
+#
+#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+#        request.addParameter("value", TYPES.VarBinary, "asdf")
+#        connection.execSql(request)
+#
+#      connection.execSqlBatch(request)
+#
+#    exec: (connection, cb) ->
+#      request = new Request "SELECT * FROM #benchmark", cb
+#      connection.execSql(request)
+#
+#    teardown: (connection, cb) ->
+#      request = new Request "DROP TABLE #benchmark", cb
+#      connection.execSqlBatch(request)
+#
+#  "varbinary (large)":
+#    setup: (connection, cb) ->
+#      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+#        return cb(err) if err
+#
+#        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+#        request.addParameter("value", TYPES.VarBinary, new Array(5 * 1024 * 1024).join("x"))
+#        connection.execSql(request)
+#
+#      connection.execSqlBatch(request)
+#
+#    exec: (connection, cb) ->
+#      request = new Request "SELECT * FROM #benchmark", cb
+#      connection.execSql(request)
+#
+#    teardown: (connection, cb) ->
+#      request = new Request "DROP TABLE #benchmark", cb
+#      connection.execSqlBatch(request)
+
+  "varbinary (huge)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.VarBinary, new Array(50 * 1024 * 1024).join("x"))
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)

--- a/benchmarks/benchmarks.coffee
+++ b/benchmarks/benchmarks.coffee
@@ -71,11 +71,7 @@ module.exports =
       connection.execSqlBatch(request)
 
     exec: (connection, cb) ->
-      request = new Request "SELECT * FROM #benchmark", (err) ->
-        console.log(arguments)
-        cb()
-      request.on "row", (data) ->
-        console.log(data[0].value.toString())
+      request = new Request "SELECT * FROM #benchmark", cb
       connection.execSql(request)
 
     teardown: (connection, cb) ->

--- a/benchmarks/query.coffee
+++ b/benchmarks/query.coffee
@@ -1,0 +1,57 @@
+fs = require "fs"
+
+Benchmark = require("benchmark")
+{Connection} = require "../src/tedious"
+
+setup = (cb) ->
+  config = JSON.parse(fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')).config
+
+  connection = new Connection(config)
+  connection.on "connect", ->
+    cb(connection)
+
+benchmarks = require("./benchmarks")
+
+setup (connection) ->
+  execute = (names, cb) ->
+    return cb() unless names.length
+
+    name = names.shift()
+
+    memMax = memStart = process.memoryUsage().rss;
+
+    benchmark = benchmarks[name]
+    benchmark.setup connection, (err) ->
+      if (err)
+        console.log("Error in '#{name}' setup:")
+        console.error(err)
+
+      bench = new Benchmark name,
+        defer: true
+        fn: (deferred) ->
+          benchmark.exec connection, (err) ->
+            if (err)
+              console.log("Error in '#{name}' execution:")
+              console.error(err)
+
+            memMax = Math.max(memMax, process.memoryUsage().rss);
+
+            deferred.resolve()
+
+      bench.on "complete", (event) ->
+        console.log(String(event.target))
+        console.log("Memory:", (memMax - memStart)/1024/1024)
+
+        benchmark.teardown connection, (err) ->
+          if (err)
+            console.log("Error in '#{name}' teardown:")
+            console.error(err)
+
+          execute(names, cb)
+
+      console.log "Benchmarking '#{name}'"
+      bench.run "async": true
+
+  execute Object.keys(benchmarks), ->
+    connection.close()
+    console.log("Done!")

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "big-number": "0.3.1",
+    "dissolve": "^0.3.3",
     "iconv-lite": "0.4.7",
     "sprintf": "0.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "async": "0.9.0",
+    "benchmark": "^1.0.0",
     "coffee-script": "1.9.0",
     "nodeunit": "0.9.0"
   },

--- a/src/message-io.coffee
+++ b/src/message-io.coffee
@@ -13,14 +13,14 @@ class ReadablePacketStream extends Dissolve
     super()
 
     @loop (end) ->
-      @uint8("type")
-      @uint8("status")
-      @uint16be("length")
-      @uint16be("spid")
-      @uint8("packetId")
-      @uint8("window")
+      @uint8 "type"
+      @uint8 "status"
+      @uint16be "length"
+      @uint16be "spid"
+      @uint8 "packetId"
+      @uint8 "window"
       @tap ->
-        @buffer("data", @vars.length - packetHeaderLength)
+        @buffer "data", @vars.length - packetHeaderLength
       @tap ->
         @push
           data: @vars.data

--- a/src/token/streaming/colmetadata-token-parser.coffee
+++ b/src/token/streaming/colmetadata-token-parser.coffee
@@ -1,0 +1,64 @@
+# s2.2.7.4
+
+metadataParse = require('./metadata-parser')
+
+readTableName = ->
+  if @options.tdsVersion >= '7_2'
+    @uint8 "tableNameParts"
+
+    @vars.tableName = []
+    @loop (end) ->
+      return end(true) if @vars.tableName.length == @vars.tableNameParts
+
+      @usVarchar("part").tap -> @vars.tableName.push(@vars.part)
+
+    @tap ->
+      # Cleanup
+      delete @vars.part
+      delete @vars.tableNameParts
+  else
+    @usVarchar "tableName"
+
+readColumnName = (c) ->
+  @bVarchar "colName"
+  if @options.columnNameReplacer
+    @tap -> @vars.colName = @options.columnNameReplacer(@vars.colName, c, @vars.metadata)
+  else if @options.camelCaseColumns
+    @tap -> @vars.colName = @vars.colName.replace /^[A-Z]/, (s) -> s.toLowerCase()
+
+module.exports = (buffer, colMetadata, options) ->
+  @uint16le "columnCount"
+  @tap ->
+    @vars.columns = []
+    @loop (end) ->
+      if @vars.columns.length == @vars.columnCount
+        return end(true)
+
+      metadataParse.call(@)
+
+      @tap ->
+        if @vars.metadata.type.hasTableName
+          readTableName.call(@)
+
+      readColumnName.call(@, @vars.columns.length)
+
+      @tap ->
+        @vars.columns.push
+          userType: @vars.metadata.userType
+          flags: @vars.metadata.flags
+          type: @vars.metadata.type
+          colName: @vars.colName
+          collation: @vars.metadata.collation
+          precision: @vars.metadata.precision
+          scale: @vars.metadata.scale
+          udtInfo: @vars.metadata.udtInfo
+          dataLength: @vars.metadata.dataLength
+          tableName: @vars.tableName
+
+  @tap ->
+
+    @colMetadata = @vars.columns
+    @push
+      name: 'COLMETADATA'
+      event: 'columnMetadata'
+      columns: @vars.columns

--- a/src/token/streaming/done-token-parser.coffee
+++ b/src/token/streaming/done-token-parser.coffee
@@ -1,0 +1,51 @@
+STATUS =
+  MORE: 0x0001
+  ERROR: 0x0002
+  # This bit is not yet in use by SQL Server,
+  # so is not exposed in the returned token.
+  INXACT: 0x0004
+  COUNT: 0x0010
+  ATTN: 0x0020
+  SRVERROR: 0x0100
+
+TYPE = require("../token").TYPE
+
+module.exports = ->
+  @uint16le("status").uint16le("curCmd").tap ->
+    if @options.tdsVersion < "7_2"
+      @uint32le("rowCount")
+    else
+      # If rowCount > 53 bits then rowCount will be incorrect
+      # (because Javascript uses IEEE_754 for number representation).
+      @uint64le("rowCount")
+
+  @tap ->
+    {status, curCmd, rowCount} = @vars
+
+    more = !!(status & STATUS.MORE)
+    sqlError = !!(status & STATUS.ERROR)
+    inTxn = !!(status & STATUS.INXACT)
+    rowCountValid = !!(status & STATUS.COUNT)
+    attention = !!(status & STATUS.ATTN)
+    serverError = !!(status & STATUS.SRVERROR)
+
+    token =
+      more: more
+      sqlError: sqlError
+      attention: attention
+      serverError: serverError
+      rowCount: rowCount if rowCountValid
+      curCmd: curCmd
+
+    switch @vars.type
+      when TYPE.DONE
+        token.name = 'DONE'
+        token.event = 'done'
+      when TYPE.DONEPROC
+        token.name = 'DONEPROC'
+        token.event = 'doneProc'
+      when TYPE.DONEINPROC
+        token.name = 'DONEINPROC'
+        token.event = 'doneInProc'
+
+    @push(token)

--- a/src/token/streaming/env-change-token-parser.coffee
+++ b/src/token/streaming/env-change-token-parser.coffee
@@ -1,0 +1,83 @@
+# s2.2.7.8
+
+types =
+  1:
+    name: 'DATABASE'
+    event: 'databaseChange'
+  2:
+    name: 'LANGUAGE',
+    event: 'languageChange'
+  3:
+    name: 'CHARSET'
+    event: 'charsetChange'
+  4:
+    name: 'PACKET_SIZE'
+    event: 'packetSizeChange'
+  7:
+    name: 'SQL_COLLATION'
+    event: 'sqlCollationChange'
+  8:
+    name: 'BEGIN_TXN'
+    event: 'beginTransaction'
+  9:
+    name: 'COMMIT_TXN'
+    event: 'commitTransaction'
+  10:
+    name: 'ROLLBACK_TXN'
+    event: 'rollbackTransaction'
+  13:
+    name: 'DATABASE_MIRRORING_PARTNER'
+    event: 'partnerNode'
+  17:
+    name: 'TXN_ENDED'
+  18:
+    name: 'RESET_CONNECTION'
+    event: 'resetConnection'
+  20:
+    name: 'ROUTING_CHANGE'
+    event: 'routingChange'
+
+module.exports = ->
+  @uint16le("length")
+  @uint8("typeNumber")
+  @tap ->
+    type = types[@vars.typeNumber]
+
+    if !type
+      console.error "Tedious > Unsupported ENVCHANGE type #{@vars.typeNumber}"
+      # Skip unknown bytes
+      return @buffer("_", @vars.length - 1)
+    
+    switch type.name
+      when 'DATABASE', 'LANGUAGE', 'CHARSET', 'PACKET_SIZE', 'DATABASE_MIRRORING_PARTNER'
+        @bVarchar("newValue")
+        @bVarchar("oldValue")
+        if type.name == 'PACKET_SIZE'
+          @tap ->
+            @vars.newValue = parseInt(@vars.newValue)
+            @vars.oldValue = parseInt(@vars.oldValue)
+      when 'SQL_COLLATION', 'BEGIN_TXN', 'COMMIT_TXN', 'ROLLBACK_TXN', 'RESET_CONNECTION'
+        @bVarbyte("newValue")
+        @bVarbyte("oldValue")
+      when 'ROUTING_CHANGE'
+        @uint8("protocol")
+        @tap ->
+          if protocol != 0
+            throw new Error('Unknown protocol byte in routing change event')
+        @uint16le("port")
+        @usVarchar("server")
+        @uint16le("_") # Skip 2 bytes for old value
+        @tap ->
+          @vars.oldValue = {}
+          @vars.newValue =
+            protocol: @vars.protocol
+            port: @vars.port
+            server: @vars.server
+
+    @tap ->
+      @push
+        name: 'ENVCHANGE'
+        type: type.name
+        event: type.event
+        oldValue: @vars.oldValue
+        newValue: @vars.newValue

--- a/src/token/streaming/guid-parser.coffee
+++ b/src/token/streaming/guid-parser.coffee
@@ -1,0 +1,55 @@
+guidToArray = (guid) ->
+    b1 = parseInt(guid.substring(6,8), 16)
+    b2 = parseInt(guid.substring(4,6), 16)
+    b3 = parseInt(guid.substring(2,4), 16)
+    b4 = parseInt(guid.substring(0,2), 16)
+    b5 = parseInt(guid.substring(11,13), 16)
+    b6 = parseInt(guid.substring(9,11), 16)
+    b7 = parseInt(guid.substring(16,18), 16)
+    b8 = parseInt(guid.substring(14,16), 16)
+    
+    b9 = parseInt(guid.substring(19,21), 16)
+    b10 = parseInt(guid.substring(21,23), 16)
+    
+    b11 = parseInt(guid.substring(24,26), 16)
+    b12 = parseInt(guid.substring(26,28), 16)
+    b13 = parseInt(guid.substring(28,30), 16)
+    b14 = parseInt(guid.substring(30,32), 16)
+    b15 = parseInt(guid.substring(32,34), 16)
+    b16 = parseInt(guid.substring(34,36), 16)
+    
+    final = [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16]
+    
+    final
+exports.guidToArray = guidToArray
+
+formatHex = (number) ->
+    hex = number.toString(16)
+    if hex.length == 1
+        hex = '0' + hex
+    return hex
+
+arrayToGuid = (array) ->
+    guid = formatHex(array[3]) +
+        formatHex(array[2]) +
+        formatHex(array[1]) +
+        formatHex(array[0]) +
+        '-' +
+        formatHex(array[5]) +
+        formatHex(array[4]) +
+        '-' +
+        formatHex(array[7]) +
+        formatHex(array[6]) +
+        '-' +
+        formatHex(array[8]) +
+        formatHex(array[9]) +
+        '-' +
+        formatHex(array[10]) +
+        formatHex(array[11]) +
+        formatHex(array[12]) +
+        formatHex(array[13]) +
+        formatHex(array[14]) +
+        formatHex(array[15])
+    guid.toUpperCase()
+
+exports.arrayToGuid = arrayToGuid

--- a/src/token/streaming/infoerror-token-parser.coffee
+++ b/src/token/streaming/infoerror-token-parser.coffee
@@ -1,0 +1,34 @@
+# s2.2.7.9, s2.2.7.10
+TYPE = require("../token").TYPE
+
+module.exports = ->
+  @uint16le "length"
+  @uint32le "number"
+  @uint8 "state"
+  @uint8 "class"
+  @usVarchar "message"
+  @bVarchar "serverName"
+  @bVarchar "procName"
+  @tap ->
+    if @options.tdsVersion < '7_2'
+      @uint16le "lineNumber"
+    else
+      @uint32le "lineNumber"
+  @tap ->
+    token =
+      number: @vars.number
+      state: @vars.state
+      class: @vars.class
+      message: @vars.message
+      serverName: @vars.serverName
+      procName: @vars.procName
+      lineNumber: @vars.lineNumber
+
+    if @vars.type == TYPE.ERROR
+      token.name = 'ERROR'
+      token.event = 'errorMessage'
+    else
+      token.name = 'INFO'
+      token.event = 'infoMessage'
+
+    @push token

--- a/src/token/streaming/loginack-token-parser.coffee
+++ b/src/token/streaming/loginack-token-parser.coffee
@@ -1,0 +1,26 @@
+# s2.2.7.11
+
+versions = require('../../tds-versions').versionsByValue
+
+interfaceTypes =
+  0: 'SQL_DFLT'
+  1: 'SQL_TSQL'
+
+module.exports = ->
+  @uint16le "length"
+  @uint8 "interfaceNumber"
+  @uint32be "tdsVersionNumber"
+  @bVarchar "progName"
+  @tap "progVersion", ->
+    @uint8 "major"
+    @uint8 "minor"
+    @uint8 "buildNumHi"
+    @uint8 "buildNumLow"
+  @tap ->
+    @push
+      name: 'LOGINACK'
+      event: 'loginack'
+      interface: interfaceTypes[@vars.interfaceNumber]
+      tdsVersion: versions[@vars.tdsVersionNumber]
+      progName: @vars.progName
+      progVersion: @vars.progVersion

--- a/src/token/streaming/metadata-parser.coffee
+++ b/src/token/streaming/metadata-parser.coffee
@@ -1,0 +1,84 @@
+codepageByLcid = require('../../collation').codepageByLcid
+
+TYPE = require('../../data-type').TYPE
+sprintf = require('sprintf').sprintf
+
+module.exports = ->
+  @tap "metadata", ->
+    if @options.tdsVersion < "7_2"
+      @uint16le "userType"
+    else
+      @uint32le "userType"
+
+    @uint16le "flags"
+    @uint8 "typeNumber"
+    @tap ->
+      @vars.type = type = TYPE[@vars.typeNumber]
+
+      if !type
+        throw new Error(sprintf('Unrecognised data type 0x%02X', typeNumber))
+
+      @vars.dataLength = undefined
+      if (type.id & 0x30) == 0x20
+        # xx10xxxx - s2.2.4.2.1.3
+        # Variable length
+        switch type.dataLengthLength
+          when 0
+            @vars.dataLength = undefined
+          when 1
+            @uint8 "dataLength"
+          when 2
+            @uint16le "dataLength"
+          when 4
+            @uint32le "dataLength"
+          else
+            throw new Error("Unsupported dataLengthLength #{type.dataLengthLength} for data type #{type.name}")
+
+      @uint8 "precision" if type.hasPrecision
+
+      if type.hasScale
+        @uint8 "scale"
+        if type.dataLengthFromScale
+          @tap ->
+            @vars.dataLength = type.dataLengthFromScale @vars.scale
+
+      if type.hasCollation
+        @buffer("collationData", 5)
+        @tap ->
+          collationData = @vars.collationData
+          delete @vars.collationData
+
+          collation = {}
+
+          collation.lcid = (collationData[2] & 0x0F) << 16
+          collation.lcid |= collationData[1] << 8
+          collation.lcid |= collationData[0]
+
+          collation.codepage = codepageByLcid[collation.lcid]
+
+          # This may not be extracting the correct nibbles in the correct order.
+          collation.flags = collationData[3] >> 4
+          collation.flags |= collationData[2] & 0xF0
+
+          # This may not be extracting the correct nibble.
+          collation.version = collationData[3] & 0x0F
+
+          collation.sortId = collationData[4]
+          @vars.collation = collation
+
+      if type.hasSchemaPresent
+        @uint8 "schemaPresent"
+        @tap ->
+          if @vars.schemaPresent == 0x01
+            @tap "schema", ->
+              @bVarchar "dbname"
+              @bVarchar "owningSchema"
+              @usVarchar "xmlSchemaCollection"
+
+      if type.hasUDTInfo
+        @tap "udtInfo", ->
+          @uint16le "maxByteSize"
+          @bVarchar "dbname"
+          @bVarchar "owningSchema"
+          @bVarchar "typeName"
+          @usVarchar "assemblyName"

--- a/src/token/streaming/nbcrow-token-parser.coffee
+++ b/src/token/streaming/nbcrow-token-parser.coffee
@@ -27,9 +27,6 @@ parser = ->
           valueParse.call(@, columnMetaData)
 
         @tap ->
-
-          console.log("value", @vars.value)
-
           column =
             value: @vars.value
             metadata: columnMetaData

--- a/src/token/streaming/nbcrow-token-parser.coffee
+++ b/src/token/streaming/nbcrow-token-parser.coffee
@@ -1,0 +1,45 @@
+# s2.2.7.13 (introduced in TDS 7.3.B)
+
+valueParse = require('./value-parser')
+sprintf = require('sprintf').sprintf
+
+parser = ->
+  length = Math.ceil @colMetadata.length / 8
+
+  bitmap = []
+  @buffer "bytes", length
+  @tap ->
+    for byte in @vars.bytes
+      for i in [0..7]
+        bitmap.push if byte & (1 << i) then true else false
+
+  columns = if @options.useColumnNames then {} else []
+
+  @tap ->
+    for columnMetaData, index in @colMetadata
+      do (columnMetaData) =>
+        #console.log sprintf('Token @ 0x%02X', buffer.position)
+
+        if bitmap[index]
+          @vars.value = null
+        else
+          valueParse.call(@, columnMetaData)
+
+        @tap ->
+          column =
+            value: @vars.value
+            metadata: columnMetaData
+
+          if @options.useColumnNames
+            unless columns[columnMetaData.colName]?
+              columns[columnMetaData.colName] = column
+          else
+            columns.push(column)
+
+  @tap ->
+    @push
+      name: 'NBCROW'
+      event: 'row'
+      columns: columns
+
+module.exports = parser

--- a/src/token/streaming/nbcrow-token-parser.coffee
+++ b/src/token/streaming/nbcrow-token-parser.coffee
@@ -21,11 +21,15 @@ parser = ->
         #console.log sprintf('Token @ 0x%02X', buffer.position)
 
         if bitmap[index]
-          @vars.value = null
+          @tap ->
+            @vars.value = null
         else
           valueParse.call(@, columnMetaData)
 
         @tap ->
+
+          console.log("value", @vars.value)
+
           column =
             value: @vars.value
             metadata: columnMetaData

--- a/src/token/streaming/order-token-parser.coffee
+++ b/src/token/streaming/order-token-parser.coffee
@@ -1,0 +1,21 @@
+# s2.2.7.14
+
+module.exports = ->
+  columnCount = 0
+  orderColumns = []
+
+  @uint16le("length").tap ->
+    columnCount = @vars.length / 2
+
+  @loop (end) ->
+    if columnCount == orderColumns.length
+      return end(true)
+
+    @uint16le("column").tap ->
+      orderColumns.push(@vars.column)
+
+  @tap ->
+    @push
+      name: 'ORDER'
+      event: 'order'
+      orderColumns: orderColumns

--- a/src/token/streaming/parser.coffee
+++ b/src/token/streaming/parser.coffee
@@ -1,0 +1,112 @@
+Dissolve = require("dissolve")
+
+TYPE = require('../token').TYPE
+
+tokenParsers = {}
+tokenParsers[TYPE.COLMETADATA] = require('./colmetadata-token-parser')
+tokenParsers[TYPE.DONE] = require('./done-token-parser')
+tokenParsers[TYPE.DONEINPROC] = require('./done-token-parser')
+tokenParsers[TYPE.DONEPROC] = require('./done-token-parser')
+tokenParsers[TYPE.ENVCHANGE] = require('./env-change-token-parser')
+tokenParsers[TYPE.ERROR] = require('./infoerror-token-parser')
+tokenParsers[TYPE.INFO] = require('./infoerror-token-parser')
+tokenParsers[TYPE.LOGINACK] = require('./loginack-token-parser')
+tokenParsers[TYPE.ORDER] = require('./order-token-parser')
+tokenParsers[TYPE.RETURNSTATUS] = require('./returnstatus-token-parser')
+tokenParsers[TYPE.RETURNVALUE] = require('./returnvalue-token-parser')
+tokenParsers[TYPE.ROW] = require('./row-token-parser')
+tokenParsers[TYPE.NBCROW] = require('./nbcrow-token-parser')
+tokenParsers[TYPE.SSPI] = require('./sspi-token-parser')
+
+module.exports = class Parser extends Dissolve
+  constructor: (@debug, @colMetadata, @options) ->
+    super()
+
+    @loop ->
+      @vars = Object.create(null)
+
+      @uint8("type")
+      @tap ->
+        if tokenParsers[@vars.type]
+          tokenParsers[@vars.type].call(@)
+        else
+          throw new Error("Token type #{@vars.type} not implemented")
+
+  # Read a Unicode String (BVARCHAR)
+  bVarchar: (name) ->
+    len = "__#{name}_len"
+
+    @uint8(len).tap ->
+      @buffer(name, @vars[len] * 2).tap ->
+        delete @vars[len]
+        @vars[name] = @vars[name].toString("ucs2")
+
+  # Read a Unicode String (USVARCHAR)
+  usVarchar: (name) ->
+    len = "__#{name}_len"
+
+    @uint16le(len).tap ->
+      @buffer(name, @vars[len] * 2).tap ->
+        delete @vars[len]
+        @vars[name] = @vars[name].toString("ucs2")
+
+  # Read binary data (BVARBYTE)
+  bVarbyte: (name) ->
+    len = "__#{name}_len"
+
+    @uint8(len).tap ->
+      @buffer(name, @vars[len]).tap ->
+        delete @vars[len]
+
+  uint24le: (name) ->
+    low = "__#{name}_low"
+    high = "__#{name}_high"
+
+    @uint16(low).uint8(high).tap ->
+      @vars[name] = @vars[low] | (@vars[high] << 16)
+      delete @vars[low]
+      delete @vars[high]
+
+  uint40le: (name) ->
+    low = "__#{name}_low"
+    high = "__#{name}_high"
+
+    @uint32le(low).uint8(high).tap ->
+      @vars[name] = (0x100000000 * @vars[high]) + @vars[low]
+      delete @vars[low]
+      delete @vars[high]
+
+  unumeric64le: (name) ->
+    low = "__#{name}_low"
+    high = "__#{name}_high"
+
+    @uint32le(low).uint32le(high).tap ->
+      @vars[name] = (0x100000000 * @vars[high]) + @vars[low]
+      delete @vars[low]
+      delete @vars[high]
+
+  unumeric96le: (name) ->
+    dword1 = "__#{name}_dword1"
+    dword2 = "__#{name}_dword2"
+    dword3 = "__#{name}_dword3"
+
+    @uint32le(dword1).uint32le(dword2).uint32le(dword3).tap ->
+      @vars[name] = @vars[dword1] + (0x100000000 * @vars[dword2]) + (0x100000000 * 0x100000000 * @vars[dword3])
+
+      delete @vars[dword1]
+      delete @vars[dword2]
+      delete @vars[dword3]
+
+  unumeric128le: (name) ->
+    dword1 = "__#{name}_dword1"
+    dword2 = "__#{name}_dword2"
+    dword3 = "__#{name}_dword3"
+    dword4 = "__#{name}_dword4"
+
+    @uint32le(dword1).uint32le(dword2).uint32le(dword3).uint32le(dword4).tap ->
+      @vars[name] = @vars[dword1] + (0x100000000 * @vars[dword2]) + (0x100000000 * 0x100000000 * @vars[dword3]) + (0x100000000 * 0x100000000 * 0x100000000 * @vars[dword4])
+
+      delete @vars[dword1]
+      delete @vars[dword2]
+      delete @vars[dword3]
+      delete @vars[dword4]

--- a/src/token/streaming/returnstatus-token-parser.coffee
+++ b/src/token/streaming/returnstatus-token-parser.coffee
@@ -1,0 +1,9 @@
+# s2.2.7.16
+
+module.exports = ->
+  @int32le "value"
+  @tap ->
+    @push
+      name: 'RETURNSTATUS'
+      event: 'returnStatus'
+      value: @vars.value

--- a/src/token/streaming/returnvalue-token-parser.coffee
+++ b/src/token/streaming/returnvalue-token-parser.coffee
@@ -1,0 +1,25 @@
+# s2.2.7.16
+
+metadataParse = require('./metadata-parser')
+valueParse = require('./value-parser')
+
+module.exports = ->
+  @uint16le "paramOrdinal"
+  @bVarchar "paramName"
+  @uint8 "status"
+  metadataParse.call(@)
+
+  @tap ->
+    valueParse.call(@, @vars.metadata)
+
+  @tap ->
+    if @vars.paramName.charAt(0) == '@'
+      @vars.paramName = @vars.paramName.slice(1)
+
+    @push
+      name: 'RETURNVALUE'
+      event: 'returnValue'
+      paramOrdinal: @vars.paramOrdinal
+      paramName: @vars.paramName
+      metadata: @vars.metadata
+      value: @vars.value

--- a/src/token/streaming/row-token-parser.coffee
+++ b/src/token/streaming/row-token-parser.coffee
@@ -1,0 +1,33 @@
+# s2.2.7.17
+
+valueParse = require('./value-parser')
+sprintf = require('sprintf').sprintf
+
+parser = ->
+  columns = if @options.useColumnNames then {} else []
+
+  for columnMetaData in @colMetadata
+    do (columnMetaData) =>
+      #console.log sprintf('Token @ 0x%02X', buffer.position)
+
+      valueParse.call(@, columnMetaData)
+      @tap ->
+        column =
+          value: @vars.value
+          metadata: columnMetaData
+        
+        if @options.useColumnNames
+          unless columns[columnMetaData.colName]?
+            columns[columnMetaData.colName] = column
+        else
+          columns.push(column)
+
+  @tap ->
+
+    @push
+      # Return token
+      name: 'ROW'
+      event: 'row'
+      columns: columns
+
+module.exports = parser

--- a/src/token/streaming/sspi-token-parser.coffee
+++ b/src/token/streaming/sspi-token-parser.coffee
@@ -1,0 +1,24 @@
+module.exports = ->
+  @buffer "junk", 3
+  @tap "challenge", ->
+    @string "magic", 8
+    @int32le "type"
+    @int16le "domainLen"
+    @int16le "domainMax"
+    @ing32le "domainOffset"
+    @int32le "flags"
+    @buffer "nonce", 8
+    @buffer "zeroes", 8
+    @int16le "targetLen"
+    @int16le "targetMax"
+    @int32le "targetOffset"
+    @buffer "oddData", 8
+    @buffer "domain", "domainLen"
+    @buffer "target", "targetLen"
+  @tap ->
+    @vars.challenge.domain = @vars.challenge.domain.toString('ucs2')
+
+    @push
+      name: 'SSPICHALLENGE'
+      event: 'sspichallenge'
+      ntlmpacket: @vars.challenge

--- a/src/token/streaming/value-parser.coffee
+++ b/src/token/streaming/value-parser.coffee
@@ -1,0 +1,384 @@
+iconv = require('iconv-lite')
+sprintf = require('sprintf').sprintf
+guidParser = require('./guid-parser')
+
+convertLEBytesToString = require('../../tracking-buffer/bigint').convertLEBytesToString
+
+NULL = (1 << 16) - 1
+MAX = (1 << 16) - 1
+THREE_AND_A_THIRD = 3 + (1 / 3)
+MONEY_DIVISOR = 10000
+
+PLP_NULL = new Buffer([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
+UNKNOWN_PLP_LEN = new Buffer([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
+
+DEFAULT_ENCODING = 'utf8'
+
+parseNull = ->
+
+module.exports = (metaData) ->
+  type = metaData.type
+
+  @tap ->
+    delete @vars.dataLength
+    delete @vars.value
+
+  if type.hasTextPointerAndTimestamp
+    @uint8 "textPointerLength"
+    @tap ->
+      if @vars.textPointerLength != 0
+        @buffer "_", "textPointerLength"
+        @buffer "_", 8
+      else
+        @vars.dataLength = 0
+        @vars.textPointerNull = true
+
+  @tap ->
+    if !@vars.dataLength && @vars.dataLength != 0
+      # s2.2.4.2.1
+      switch type.id & 0x30
+        when 0x10 # xx01xxxx - s2.2.4.2.1.1
+          # Zero length
+          @vars.dataLength = 0
+        when 0x20 # xx10xxxx - s2.2.4.2.1.3
+          # Variable length
+          if metaData.dataLength != MAX
+            switch type.dataLengthLength
+              when 0
+                @vars.dataLength = undefined
+              when 1
+                @uint8 "dataLength"
+              when 2
+                @uint16le "dataLength"
+              when 4
+                @uint32le "dataLength"
+              else
+                throw Error("Unsupported dataLengthLength #{type.dataLengthLength} for data type #{type.name}")
+
+        when 0x30 # xx11xxxx - s2.2.4.2.1.2
+          # Fixed length
+          @vars.dataLength = 1 << ((type.id & 0x0C) >> 2)
+
+  @tap ->
+    switch type.name
+      when 'Null'
+        @vars.value = null
+      when 'TinyInt'
+        @uint8 "value"
+      when 'SmallInt'
+        @int16le "value"
+      when 'Int'
+        @int32le "value"
+      when 'BigInt'
+        @buffer "value", 8
+        @tap -> @vars.value = convertLEBytesToString(@vars.value)
+      when 'IntN'
+        switch @vars.dataLength
+          when 0
+            @vars.value = null
+          when 1
+            @uint8 "value"
+          when 2
+            @int16le "value"
+          when 4
+            @int32le "value"
+          when 8
+            @buffer "value", 8
+            @tap -> @vars.value = convertLEBytesToString(@vars.value)
+          else
+            throw new Error("Unsupported dataLength #{@vars.dataLength} for IntN")
+      when 'Real'
+        @floatle "value"
+      when 'Float'
+        @doublele "value"
+      when 'FloatN'
+        switch @vars.dataLength
+          when 0
+            @vars.value = null
+          when 4
+            @floatle "value"
+          when 8
+            @doublele "value"
+          else
+            throw new Error("Unsupported dataLength #{@vars.dataLength} for FloatN")
+      when 'Money', 'SmallMoney', 'MoneyN'
+        switch @vars.dataLength
+          when 0
+            @vars.value = null
+          when 4
+            @int32le "value"
+            @tap -> @vars.value = @vars.value / MONEY_DIVISOR
+          when 8
+            @int32le "_value__high"
+            @uint32le "_value__low"
+
+            @tap ->
+              @vars.value = @vars._value__low + (0x100000000 * @vars._value__high)
+              @vars.value /= MONEY_DIVISOR
+              delete @vars._value__high
+              delete @vars._value__low
+          else
+            throw new Error("Unsupported dataLength #{@vars.dataLength} for MoneyN")
+      when 'Bit'
+        @uint8 "value"
+        @tap -> @vars.value = !!@vars.value
+      when 'BitN'
+        switch @vars.dataLength
+          when 0
+            @vars.value = null
+          when 1
+            @uint8 "value"
+            @tap -> @vars.value = !!@vars.value
+      when 'VarChar', 'Char'
+        codepage = metaData.collation.codepage
+        if metaData.dataLength == MAX
+          readMaxChars.call(@, codepage)
+        else
+          readChars.call(@, @vars.dataLength, codepage)
+      when 'NVarChar', 'NChar'
+        if metaData.dataLength == MAX
+          readMaxNChars.call(@)
+        else
+          readNChars.call(@, @vars.dataLength)
+      when 'VarBinary', 'Binary'
+        if metaData.dataLength == MAX
+          readMaxBinary.call(@)
+        else
+          readBinary.call(@, @vars.dataLength)
+      when 'Text'
+        if @vars.textPointerNull
+          @vars.value = null
+        else
+          readChars.call(@, @vars.dataLength, metaData.collation.codepage)
+      when 'NText'
+        if @vars.textPointerNull
+          @vars.value = null
+        else
+          readNChars.call(@, @vars.dataLength)
+      when 'Image'
+        if @vars.textPointerNull
+          @vars.value = null
+        else
+          readBinary.call(@, @vars.dataLength)
+      when 'Xml'
+        readMaxNChars.call(@)
+      when 'SmallDateTime'
+        readSmallDateTime.call(@)
+      when 'DateTime'
+        readDateTime.call(@)
+      when 'DateTimeN'
+        switch @vars.dataLength
+          when 0
+            @vars.value = null
+          when 4
+            readSmallDateTime.call(@)
+          when 8
+            readDateTime.call(@)
+      when 'TimeN'
+        @uint8 "dataLength"
+        @tap ->
+          if @vars.dataLength == 0
+            @vars.value = null
+          else
+            readTime.call @, @vars.dataLength, metaData.scale
+      when 'DateN'
+        @uint8 "dataLength"
+        @tap ->
+          if @vars.dataLength == 0
+            @vars.value = null
+          else
+            readDate.call(@)
+      when 'DateTime2N'
+        @uint8 "dataLength"
+        @tap ->
+          if @vars.dataLength == 0
+            @vars.value = null
+          else
+            readDateTime2.call @, @vars.dataLength, metaData.scale
+      when 'DateTimeOffsetN'
+        @uint8 "dataLength"
+        @tap ->
+          if @vars.dataLength == 0
+            @vars.value = null
+          else
+            readDateTimeOffset.call(@, @vars.dataLength, metaData.scale)
+      when 'NumericN', 'DecimalN'
+        if @vars.dataLength == 0
+          @vars.value = null
+        else
+          @uint8("sign").tap -> @vars.sign = -1 unless @vars.sign == 1
+
+          switch @vars.dataLength - 1
+            when 4
+              @uint32le "value"
+            when 8
+              @unumeric64le "value"
+            when 12
+              @unumeric96le "value"
+            when 16
+              @unumeric128le "value"
+            else
+              throw new Error(sprintf('Unsupported numeric size %d', @vars.dataLength - 1))
+
+          @tap ->
+            @vars.value *= @vars.sign
+            @vars.value /= Math.pow(10, metaData.scale)
+
+      when 'UniqueIdentifierN'
+        switch @vars.dataLength
+          when 0
+            @vars.value = null
+          when 0x10
+            @buffer "value", 0x10
+            @tap -> @vars.value = guidParser.arrayToGuid(Array.prototype.slice.call(@vars.value, 0, @vars.value.length))
+          else
+            throw new Error(sprintf('Unsupported guid size %d at offset 0x%04X', @vars.dataLength - 1, buffer.position))
+      when 'UDT'
+        readMaxBinary.call(@)
+      else
+        throw new Error(sprintf('Unrecognised type %s at offset 0x%04X', type.name, buffer.position))
+        break
+
+readBinary = (dataLength) ->
+  if dataLength == NULL
+    @vars.value = null
+  else
+    @buffer "value", dataLength
+
+readChars = (dataLength, codepage=DEFAULT_ENCODING) ->
+  if dataLength == NULL
+    @vars.value = null
+  else
+    @buffer "value", dataLength
+    @tap -> @vars.value = iconv.decode(@vars.value, codepage)
+    
+readNChars = (dataLength) ->
+  if dataLength == NULL
+    @vars.value = null
+  else
+    @buffer "value", dataLength
+    @tap -> @vars.value = @vars.value.toString('ucs2')
+
+readMaxBinary = () ->
+  readMax.call(@)
+
+readMaxChars = (codepage=DEFAULT_ENCODING) ->
+  readMax.call(@)
+  @tap ->
+    @vars.value = iconv.decode(@vars.value, codepage) if @vars.value
+
+readMaxNChars = () ->
+  readMax.call(@)
+  @tap -> @vars.value = @vars.value.toString('ucs2') if @vars.value
+
+readMax = (decodeFunction) ->
+  @buffer "length", 8
+  @tap ->
+    if @vars.length.equals(PLP_NULL)
+      @vars.value = null
+    else
+      unless @vars.length.equals(UNKNOWN_PLP_LEN)
+        low = @vars.length.readUInt32LE(0)
+        high = @vars.length.readUInt32LE(4)
+
+        if (high >= (2 << (53 - 32)))
+          console.warn("Read UInt64LE > 53 bits : high=#{high}, low=#{low}")
+
+        expectedLength = low + (0x100000000 * high)
+
+      length = 0
+      chunks = []
+
+      @loop (end) ->
+        @uint32le "chunkLength"
+        @tap ->
+          return end(true) if @vars.chunkLength == 0
+          length += @vars.chunkLength
+          @buffer "chunkData", "chunkLength"
+          @tap -> chunks.push @vars.chunkData
+
+      @tap ->
+        if expectedLength && length != expectedLength
+          throw new Error("Partially Length-prefixed Bytes unmatched lengths : expected #{expectedLength}, but got #{length} bytes")
+
+      @tap ->
+        @vars.value = Buffer.concat(chunks, length)
+
+readSmallDateTime = ->
+  @uint16le "days"
+  @uint16le "minutes"
+
+  @tap ->
+    if @options.useUTC
+      value = new Date(Date.UTC(1900, 0, 1))
+      value.setUTCDate(value.getUTCDate() + @vars.days)
+      value.setUTCMinutes(value.getUTCMinutes() + @vars.minutes)
+    else
+      value = new Date(1900, 0, 1)
+      value.setDate(value.getDate() + @vars.days)
+      value.setMinutes(value.getMinutes() + @vars.minutes)
+    
+    @vars.value = value
+
+readDateTime = ->
+  @int32le "days"
+  @uint32le "milliseconds"
+  @tap -> @vars.milliseconds = @vars.milliseconds * THREE_AND_A_THIRD
+
+  @tap ->
+    if @options.useUTC
+      value = new Date(Date.UTC(1900, 0, 1))
+      value.setUTCDate(value.getUTCDate() + @vars.days)
+      value.setUTCMilliseconds(value.getUTCMilliseconds() + @vars.milliseconds)
+    else
+      value = new Date(1900, 0, 1)
+      value.setDate(value.getDate() + @vars.days)
+      value.setMilliseconds(value.getMilliseconds() + @vars.milliseconds)
+      
+    @vars.value = value
+
+readTime = (dataLength, scale) ->
+  switch dataLength
+    when 3 then @uint24le "milliseconds"
+    when 4 then @uint32le "milliseconds"
+    when 5 then @uint40le "milliseconds"
+
+  if scale < 7
+    @tap -> @vars.milliseconds *= 10 for i in [scale + 1..7]
+  
+  @tap ->
+    @vars.value = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, @vars.milliseconds / 10000))
+    Object.defineProperty @vars.value, "nanosecondsDelta",
+      enumerable: false
+      value: (@vars.milliseconds % 10000) / Math.pow(10, 7)
+    delete @vars.milliseconds
+
+readDate = ->
+  @uint24le "days"
+  @tap ->
+    @vars.value = new Date(Date.UTC(2000, 0, @vars.days - 730118))
+    delete @vars.days
+
+readDateTime2 = (dataLength, scale) ->
+  readTime.call(@, dataLength - 3, scale)
+  @uint24le("days")
+  @tap ->
+    @vars.time = @vars.value
+
+    @vars.value = new Date(Date.UTC(2000, 0, @vars.days - 730118, 0, 0, 0, +@vars.time))
+    Object.defineProperty @vars.value, "nanosecondsDelta",
+      enumerable: false
+      value: @vars.time.nanosecondsDelta
+
+    delete @vars.time
+
+readDateTimeOffset = (dataLength, scale) ->
+  readTime.call(@, dataLength - 5, scale)
+  @uint24le "days"
+  @uint16le "offset"
+  @tap ->
+    @vars.time = @vars.value
+    @vars.value = new Date(Date.UTC(2000, 0, @vars.days - 730118, 0, 0, 0, +@vars.time))
+    Object.defineProperty @vars.value, "nanosecondsDelta",
+      enumerable: false
+      value: @vars.time.nanosecondsDelta

--- a/src/token/token-stream-parser.coffee
+++ b/src/token/token-stream-parser.coffee
@@ -43,4 +43,7 @@ class Parser extends EventEmitter
     catch error
       console.log(error)
 
+  isEnd: () ->
+    @parser._buffer.length == 0
+
 exports.Parser = Parser

--- a/src/token/token-stream-parser.coffee
+++ b/src/token/token-stream-parser.coffee
@@ -18,6 +18,8 @@ tokenParsers[TYPE.ROW] = require('./row-token-parser')
 tokenParsers[TYPE.NBCROW] = require('./nbcrow-token-parser')
 tokenParsers[TYPE.SSPI] = require('./sspi-token-parser')
 
+StreamParser = require("./streaming/parser")
+
 ###
   Buffers are thrown at the parser (by calling addBuffer).
   Tokens are parsed from the buffer until there are no more tokens in
@@ -30,62 +32,15 @@ tokenParsers[TYPE.SSPI] = require('./sspi-token-parser')
 ###
 class Parser extends EventEmitter
   constructor: (@debug, @colMetadata, @options) ->
-    @buffer = new ReadableTrackingBuffer(new Buffer(0), 'ucs2')
-    @position = 0
+    @parser = new StreamParser(@debug, @colMetadata, @options)
+
+    @parser.on "data", (token) =>
+      @emit(token.event, token) if token.event
 
   addBuffer: (buffer) ->
-    @buffer.add(buffer)
-    @position = @buffer.position
-
-    while @nextToken()
-      'NOOP'
-
-    # Position to the end of the last successfully parsed token.
-    @buffer.position = @position
-
-  isEnd: ->
-    @buffer.empty()
-
-  nextToken: ->
     try
-      # check if we have available bytes
-      unless @buffer.buffer.length > @buffer.position
-        return false
-
-      type = @buffer.readUInt8()
-
-      if tokenParsers[type]
-        token = tokenParsers[type](@buffer, @colMetadata, @options)
-
-        if token
-          @debug.token(token)
-
-          # Note current position, so that it can be rolled back to if the next token runs out of buffer.
-          @position = @buffer.position
-
-          if token.event
-            @emit(token.event, token)
-
-          switch token.name
-            when 'COLMETADATA'
-              @colMetadata = token.columns
-
-          return true
-        else
-          return false
-
-      else
-        @emit 'tokenStreamError', "Unrecognized token #{type} at offset #{@buffer.position}"
-        return false
-
+      @parser.write(buffer)
     catch error
-      if error?.code == 'oob'
-        #console.error "OOB ERROR", type, error.stack
-        # There was an attempt to read past the end of the buffer.
-        # In other words, we've run out of buffer.
-        return false
-      else
-        @emit 'tokenStreamError', error
-        return false
+      console.log(error)
 
 exports.Parser = Parser

--- a/src/token/token-stream-parser.coffee
+++ b/src/token/token-stream-parser.coffee
@@ -35,6 +35,7 @@ class Parser extends EventEmitter
     @parser = new StreamParser(@debug, @colMetadata, @options)
 
     @parser.on "data", (token) =>
+      @debug.token(token)
       @emit(token.event, token) if token.event
 
   addBuffer: (buffer) ->

--- a/test/unit/token/streaming/colmetadata-token-parser-test.coffee
+++ b/test/unit/token/streaming/colmetadata-token-parser-test.coffee
@@ -1,0 +1,71 @@
+dataTypeByName = require('../../../../src/data-type').typeByName
+Parser = require('../../../../src/token/streaming/parser')
+WritableTrackingBuffer = require('../../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+module.exports.int = (test) ->
+  numberOfColumns = 1
+  userType = 2
+  flags = 3
+  columnName = 'name'
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0x81)
+  buffer.writeUInt16LE(numberOfColumns)
+  buffer.writeUInt32LE(userType)
+  buffer.writeUInt16LE(flags)
+  buffer.writeUInt8(dataTypeByName.Int.id)
+  buffer.writeBVarchar(columnName)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, {}, {})
+  parser.write(buffer.data)
+  token = parser.read()
+
+  test.ok(!token.error)
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].userType, 2)
+  test.strictEqual(token.columns[0].flags, 3)
+  test.strictEqual(token.columns[0].type.name, 'Int')
+  test.strictEqual(token.columns[0].colName, 'name')
+
+  test.done()
+
+module.exports.varchar = (test) ->
+  numberOfColumns = 1
+  userType = 2
+  flags = 3
+  length = 3
+  collation = new Buffer([0x09, 0x04, 0x50, 0x78, 0x9a])
+  columnName = 'name'
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0x81)
+  buffer.writeUInt16LE(numberOfColumns)
+  buffer.writeUInt32LE(userType)
+  buffer.writeUInt16LE(flags)
+  buffer.writeUInt8(dataTypeByName.VarChar.id)
+  buffer.writeUInt16LE(length)
+  buffer.writeBuffer(collation)
+  buffer.writeBVarchar(columnName)
+  #console.log(buffer)
+
+  parser = new Parser({}, {}, {})
+  parser.write(buffer.data)
+  token = parser.read()
+
+  test.ok(!token.error)
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].userType, 2)
+  test.strictEqual(token.columns[0].flags, 3)
+  test.strictEqual(token.columns[0].type.name, 'VarChar')
+  test.strictEqual(token.columns[0].collation.lcid, 0x0409)
+  test.strictEqual(token.columns[0].collation.codepage, 'CP1252')
+  test.strictEqual(token.columns[0].collation.flags, 0x57)
+  test.strictEqual(token.columns[0].collation.version, 0x8)
+  test.strictEqual(token.columns[0].collation.sortId, 0x9a)
+  test.strictEqual(token.columns[0].colName, 'name')
+  test.strictEqual(token.columns[0].dataLength, length)
+
+  test.done()

--- a/test/unit/token/streaming/done-token-parser-test.coffee
+++ b/test/unit/token/streaming/done-token-parser-test.coffee
@@ -1,0 +1,57 @@
+Parser = require('../../../../src/token/streaming/parser')
+WritableTrackingBuffer = require('../../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+parse = (status, curCmd, doneRowCount) ->
+  doneRowCountLow = doneRowCount % 0x100000000
+  doneRowCountHi = ~~(doneRowCount / 0x100000000)
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xFD)
+  buffer.writeUInt16LE(status)
+  buffer.writeUInt16LE(curCmd)
+  buffer.writeUInt32LE(doneRowCountLow)
+  buffer.writeUInt32LE(doneRowCountHi)
+
+  parser = new Parser({}, {}, { tdsVersion: "7_2" })
+  parser.write(buffer.data)
+  parser.read()
+
+module.exports.done = (test) ->
+  status = 0x0000
+  curCmd = 1
+  doneRowCount = 2
+
+  token = parse(status, curCmd, doneRowCount)
+
+  test.ok(!token.more)
+  test.strictEqual(token.curCmd, curCmd)
+  test.ok(!token.rowCount)
+
+  test.done()
+
+module.exports.more = (test) ->
+  status = 0x0001
+  curCmd = 1
+  doneRowCount = 2
+
+  token = parse(status, curCmd, doneRowCount)
+
+  test.ok(token.more)
+  test.strictEqual(token.curCmd, curCmd)
+  test.ok(!token.rowCount)
+
+  test.done()
+
+module.exports.doneRowCount = (test) ->
+  status = 0x0010
+  curCmd = 1
+  doneRowCount = 0x1200000034
+
+  token = parse(status, curCmd, doneRowCount)
+
+  test.ok(!token.more)
+  test.strictEqual(token.curCmd, 1)
+  test.strictEqual(token.rowCount, doneRowCount)
+
+  test.done()

--- a/test/unit/token/streaming/env-change-token-parser-test.coffee
+++ b/test/unit/token/streaming/env-change-token-parser-test.coffee
@@ -1,0 +1,69 @@
+Parser = require('../../../../src/token/streaming/parser')
+WritableTrackingBuffer = require('../../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+module.exports.database = (test) ->
+  oldDb = 'old'
+  newDb = 'new'
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xE3)
+  buffer.writeUInt16LE(0)                 # Length written later
+  buffer.writeUInt8(0x01)                 # Database
+  buffer.writeBVarchar(newDb)
+  buffer.writeBVarchar(oldDb)
+
+  data = buffer.data
+  data.writeUInt16LE(data.length - 3, 1)
+
+  parser = new Parser({}, {}, {})
+  parser.write(data)
+  token = parser.read()
+
+  test.strictEqual(token.type, 'DATABASE')
+  test.strictEqual(token.oldValue, 'old')
+  test.strictEqual(token.newValue, 'new')
+
+  test.done()
+
+module.exports.packetSize = (test) ->
+  oldSize = '1024'
+  newSize = '2048'
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xE3)
+  buffer.writeUInt16LE(0)                 # Length written later
+  buffer.writeUInt8(0x04)                 # Packet size
+  buffer.writeBVarchar(newSize)
+  buffer.writeBVarchar(oldSize)
+
+  data = buffer.data
+  data.writeUInt16LE(data.length - 3, 1)
+
+  parser = new Parser({}, {}, {})
+  parser.write(data)
+  token = parser.read()
+
+  test.strictEqual(token.type, 'PACKET_SIZE')
+  test.strictEqual(token.oldValue, 1024)
+  test.strictEqual(token.newValue, 2048)
+
+  test.done()
+
+module.exports.badType = (test) ->
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xE3)
+  buffer.writeUInt16LE(0)                 # Length written later
+  buffer.writeUInt8(0xFF)                 # Bad type
+
+  data = buffer.data
+  data.writeUInt16LE(data.length - 3, 1);
+  
+  parser = new Parser({}, {}, {})
+  parser.write(data)
+  token = parser.read()
+  
+  test.strictEqual(token, null)   
+  test.done()

--- a/test/unit/token/streaming/infoerror-token-parser-test.coffee
+++ b/test/unit/token/streaming/infoerror-token-parser-test.coffee
@@ -1,0 +1,40 @@
+Parser = require('../../../../src/token/streaming/parser')
+WritableTrackingBuffer = require('../../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+module.exports.info = (test) ->
+  number = 3
+  state = 4
+  class_ = 5
+  message = 'message'
+  serverName = 'server'
+  procName = 'proc'
+  lineNumber = 6
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xAB)
+  buffer.writeUInt16LE(0)         # Length written later
+  buffer.writeUInt32LE(number)
+  buffer.writeUInt8(state)
+  buffer.writeUInt8(class_)
+  buffer.writeUsVarchar(message)
+  buffer.writeBVarchar(serverName)
+  buffer.writeBVarchar(procName)
+  buffer.writeUInt32LE(lineNumber)
+
+  data = buffer.data
+  data.writeUInt16LE(data.length - 3, 1)
+
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(data)
+  token = parser.read()
+
+  test.strictEqual(token.number, number)
+  test.strictEqual(token.state, state)
+  test.strictEqual(token.class, class_)
+  test.strictEqual(token.message, message)
+  test.strictEqual(token.serverName, serverName)
+  test.strictEqual(token.procName, procName)
+  test.strictEqual(token.lineNumber, lineNumber)
+
+  test.done()

--- a/test/unit/token/streaming/loginack-token-parser-test.coffee
+++ b/test/unit/token/streaming/loginack-token-parser-test.coffee
@@ -1,0 +1,39 @@
+Parser = require('../../../../src/token/streaming/parser')
+WritableTrackingBuffer = require('../../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+module.exports.info = (test) ->
+  interfaceType = 1
+  version = 0x72090002
+  progName = 'prog'
+  progVersion =
+    major: 1
+    minor: 2
+    buildNumHi: 3
+    buildNumLow: 4
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xAD)
+  buffer.writeUInt16LE(0)         # Length written later
+  buffer.writeUInt8(interfaceType)
+  buffer.writeUInt32BE(version)
+  buffer.writeBVarchar(progName)
+  buffer.writeUInt8(progVersion.major)
+  buffer.writeUInt8(progVersion.minor)
+  buffer.writeUInt8(progVersion.buildNumHi)
+  buffer.writeUInt8(progVersion.buildNumLow)
+
+  data = buffer.data
+  data.writeUInt16LE(data.length - 3, 1)
+  #console.log(buffer)
+
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(data)
+  token = parser.read()
+
+  test.strictEqual(token.interface, 'SQL_TSQL')
+  test.strictEqual(token.tdsVersion, '7_2')
+  test.strictEqual(token.progName, progName)
+  test.deepEqual(token.progVersion, progVersion)
+
+  test.done()

--- a/test/unit/token/streaming/order-token-parser-test.coffee
+++ b/test/unit/token/streaming/order-token-parser-test.coffee
@@ -1,0 +1,49 @@
+Parser = require('../../../../src/token/streaming/parser')
+WritableTrackingBuffer = require('../../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+module.exports.oneColumn = (test) ->
+  numberOfColumns = 1
+  length = numberOfColumns * 2
+  column = 3
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xA9)
+  buffer.writeUInt16LE(length)
+  buffer.writeUInt16LE(column)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.orderColumns.length, 1)
+  test.strictEqual(token.orderColumns[0], column)
+
+  test.done()
+
+module.exports.twoColumns = (test) ->
+  numberOfColumns = 2
+  length = numberOfColumns * 2
+  column1 = 3
+  column2 = 4
+
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(0xA9)
+  buffer.writeUInt16LE(length)
+  buffer.writeUInt16LE(column1)
+  buffer.writeUInt16LE(column2)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.orderColumns.length, 2)
+  test.strictEqual(token.orderColumns[0], column1)
+  test.strictEqual(token.orderColumns[1], column2)
+
+  test.done()

--- a/test/unit/token/streaming/row-token-parser-test.coffee
+++ b/test/unit/token/streaming/row-token-parser-test.coffee
@@ -1,0 +1,758 @@
+Parser = require('../../../../src/token/streaming/parser')
+dataTypeByName = require('../../../../src/data-type').typeByName
+WritableTrackingBuffer = require('../../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+options =
+  useUTC: false
+  tdsVersion: '7_2'
+
+module.exports.null = (test) ->
+  colMetaData = [type: dataTypeByName.Null]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, null)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.int = (test) ->
+  colMetaData = [type: dataTypeByName.Int]
+  value = 3
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUInt32LE(value)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.bigint = (test) ->
+  colMetaData = [
+    { type: dataTypeByName.BigInt },
+    { type: dataTypeByName.BigInt }
+  ]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([
+    1,0,0,0,0,0,0,0,
+    255,255,255,255,255,255,255,127]))
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 2)
+  test.strictEqual("1", token.columns[0].value)
+  test.strictEqual("9223372036854775807", token.columns[1].value)
+
+  test.done()
+
+module.exports.real = (test) ->
+  colMetaData = [type: dataTypeByName.Real]
+  value = 9.5
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([0x00, 0x00, 0x18, 0x41]))
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.float = (test) ->
+  colMetaData = [type: dataTypeByName.Float]
+  value = 9.5
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x23, 0x40]))
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.money = (test) ->
+  colMetaData = [
+    {type: dataTypeByName.SmallMoney}
+    {type: dataTypeByName.Money}
+    {type: dataTypeByName.MoneyN}
+    {type: dataTypeByName.MoneyN}
+    {type: dataTypeByName.MoneyN}
+    {type: dataTypeByName.MoneyN}
+  ]
+  value = 123.456
+  valueLarge = 123456789012345.11
+
+  buffer = new WritableTrackingBuffer(0)
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([0x80, 0xd6, 0x12, 0x00]))
+  buffer.writeBuffer(new Buffer([0x00, 0x00, 0x00, 0x00, 0x80, 0xd6, 0x12, 0x00]))
+  buffer.writeBuffer(new Buffer([0x00]))
+  buffer.writeBuffer(new Buffer([0x04, 0x80, 0xd6, 0x12, 0x00]))
+  buffer.writeBuffer(new Buffer([0x08, 0x00, 0x00, 0x00, 0x00, 0x80, 0xd6, 0x12, 0x00]))
+  buffer.writeBuffer(new Buffer([0x08, 0xf4, 0x10, 0x22, 0x11, 0xdc, 0x6a, 0xe9, 0x7d]))
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 6)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[1].value, value)
+  test.strictEqual(token.columns[2].value, null)
+  test.strictEqual(token.columns[3].value, value)
+  test.strictEqual(token.columns[4].value, value)
+  test.strictEqual(token.columns[5].value, valueLarge)
+
+  test.done()
+
+module.exports.varCharWithoutCodepage = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarChar
+    collation:
+      codepage: undefined
+  ]
+  value = 'abcde'
+
+  buffer = new WritableTrackingBuffer(0, 'ascii')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUsVarchar(value)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varCharWithCodepage = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarChar
+    collation:
+      codepage: 'WINDOWS-1252'
+  ]
+  value = 'abcdé'
+
+  buffer = new WritableTrackingBuffer(0, 'ascii')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUsVarchar(value)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.nVarChar = (test) ->
+  colMetaData = [type: dataTypeByName.NVarChar]
+  value = 'abc'
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUInt16LE(value.length * 2)
+  buffer.writeString(value)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varBinary = (test) ->
+  colMetaData = [type: dataTypeByName.VarBinary]
+  value = new Buffer [0x12, 0x34]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUInt16LE(value.length)
+  buffer.writeBuffer(new Buffer(value))
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.deepEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.binary = (test) ->
+  colMetaData = [type: dataTypeByName.Binary]
+  value = new Buffer [0x12, 0x34]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUInt16LE(value.length)
+  buffer.writeBuffer(new Buffer(value))
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.deepEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varCharMaxNull = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarChar
+    dataLength: 65535
+    collation:
+      codepage: undefined
+  ]
+
+  buffer = new WritableTrackingBuffer(0, 'ascii')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, null)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varCharMaxUnknownLength = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarChar
+    dataLength: 65535
+    collation:
+      codepage: undefined
+  ]
+  value = 'abcdef'
+
+  buffer = new WritableTrackingBuffer(0, 'ascii')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(0, 3))
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(3, 6))
+  buffer.writeUInt32LE(0)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varCharMaxKnownLength = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarChar
+    dataLength: 65535
+    collation:
+      codepage: undefined
+  ]
+  value = 'abcdef'
+
+  buffer = new WritableTrackingBuffer(0, 'ascii')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUInt64LE(value.length)
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(0, 3))
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(3, 6))
+  buffer.writeUInt32LE(0)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varCharMaxWithCodepage = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarChar
+    dataLength: 65535
+    collation:
+      codepage: 'WINDOWS-1252'
+  ]
+  value = 'abcdéf'
+
+  buffer = new WritableTrackingBuffer(0, 'ascii')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUInt64LE(value.length)
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(0, 3))
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(3, 6))
+  buffer.writeUInt32LE(0)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varCharMaxKnownLengthWrong = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarChar
+    dataLength: 65535
+  ]
+  value = 'abcdef'
+
+  buffer = new WritableTrackingBuffer(0, 'ascii')
+  buffer.writeUInt8(0xD1)
+  buffer.writeUInt64LE(value.length + 1)
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(0, 3))
+  buffer.writeUInt32LE(3)
+  buffer.writeString(value.slice(3, 6))
+  buffer.writeUInt32LE(0)
+  #console.log(buffer.data)
+
+  try
+    parser = new Parser({}, colMetaData, options)
+    parser.write(buffer.data)
+    token = parser.read()
+    test.ok(false)
+  catch exception
+    test.done()
+
+module.exports.varBinaryMaxNull = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarBinary
+    dataLength: 65535
+  ]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, null)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.varBinaryMaxUnknownLength = (test) ->
+  colMetaData = [
+    type: dataTypeByName.VarBinary
+    dataLength: 65535
+  ]
+  value = new Buffer [0x12, 0x34, 0x56, 0x78]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))
+  buffer.writeUInt32LE(2)
+  buffer.writeBuffer(new Buffer(value.slice(0, 2)))
+  buffer.writeUInt32LE(2)
+  buffer.writeBuffer(new Buffer(value.slice(2, 4)))
+  buffer.writeUInt32LE(0)
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.deepEqual(token.columns[0].value, value)
+  test.strictEqual(token.columns[0].metadata, colMetaData[0])
+
+  test.done()
+
+module.exports.intN = (test) ->
+  colMetaData = [
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+    {type: dataTypeByName.IntN}
+  ]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([
+    0,
+    8, 0,0,0,0,0,0,0,0,
+    8, 1,0,0,0,0,0,0,0,
+    8, 255,255,255,255,255,255,255,255,
+    8, 2,0,0,0,0,0,0,0,
+    8, 254,255,255,255,255,255,255,255,
+    8, 255,255,255,255,255,255,255,127,
+    8, 0,0,0,0,0,0,0,128,
+    8, 10,0,0,0,0,0,0,0,
+    8, 100,0,0,0,0,0,0,0,
+    8, 232,3,0,0,0,0,0,0,
+    8, 16,39,0,0,0,0,0,0]))
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 12)
+  test.strictEqual(token.columns[0].value, null)
+  test.strictEqual("0", token.columns[1].value)
+  test.strictEqual("1", token.columns[2].value)
+  test.strictEqual("-1", token.columns[3].value)
+  test.strictEqual("2", token.columns[4].value)
+  test.strictEqual("-2", token.columns[5].value)
+  test.strictEqual("9223372036854775807", token.columns[6].value)
+  test.strictEqual("-9223372036854775808", token.columns[7].value)
+  test.strictEqual("10", token.columns[8].value)
+  test.strictEqual("100", token.columns[9].value)
+  test.strictEqual("1000", token.columns[10].value)
+  test.strictEqual("10000", token.columns[11].value)
+
+  test.done()
+
+module.exports.guidN = (test) ->
+  colMetaData = [
+    {type: dataTypeByName.UniqueIdentifierN}
+    {type: dataTypeByName.UniqueIdentifierN}
+  ]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([
+    0,
+    16, 0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef
+  ]))
+  # console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 2)
+  test.strictEqual(token.columns[0].value, null)
+  test.deepEqual('67452301-AB89-EFCD-0123-456789ABCDEF', token.columns[1].value)
+
+  test.done()
+
+module.exports.floatN = (test) ->
+  colMetaData = [
+    {type: dataTypeByName.FloatN}
+    {type: dataTypeByName.FloatN}
+    {type: dataTypeByName.FloatN}
+  ]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+  buffer.writeBuffer(new Buffer([
+    0,
+    4, 0x00, 0x00, 0x18, 0x41,
+    8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x23, 0x40
+  ]))
+  #console.log(buffer.data)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 3)
+  test.strictEqual(token.columns[0].value, null)
+  test.strictEqual(9.5, token.columns[1].value)
+  test.strictEqual(9.5, token.columns[2].value)
+
+  test.done()
+
+module.exports.datetime = (test) ->
+  colMetaData = [type: dataTypeByName.DateTime]
+
+  days = 2                                        # 3rd January 1900
+  threeHundredthsOfSecond = 45 * 300              # 45 seconds
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeInt32LE(days)
+  buffer.writeUInt32LE(threeHundredthsOfSecond)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, { useUTC: false })
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value.getTime(), new Date("January 3, 1900 00:00:45").getTime())
+
+  parser = new Parser({}, colMetaData, { useUTC: true })
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value.getTime(), new Date("January 3, 1900 00:00:45 GMT").getTime())
+
+  test.done()
+
+module.exports.datetimeN = (test) ->
+  colMetaData = [type: dataTypeByName.DateTimeN]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeUInt8(0)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, null)
+
+  test.done()
+
+module.exports.numeric4Bytes = (test) ->
+  colMetaData = [
+    type: dataTypeByName.NumericN
+    precision: 3
+    scale: 1
+  ]
+
+  value = 9.3
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeUInt8(1 + 4)
+  buffer.writeUInt8(1)      # positive
+  buffer.writeUInt32LE(93)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+
+  test.done()
+
+module.exports.numeric4BytesNegative = (test) ->
+  colMetaData = [
+    type: dataTypeByName.NumericN
+    precision: 3
+    scale: 1
+  ]
+
+  value = -9.3
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeUInt8(1 + 4)
+  buffer.writeUInt8(0)      # negative
+  buffer.writeUInt32LE(93)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+
+  test.done()
+
+module.exports.numeric8Bytes = (test) ->
+  colMetaData = [
+    type: dataTypeByName.NumericN
+    precision: 13
+    scale: 1
+  ]
+
+  value = (0x100000000 + 93) / 10
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeUInt8(1 + 8)
+  buffer.writeUInt8(1)      # positive
+  buffer.writeUInt32LE(93)
+  buffer.writeUInt32LE(1)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+
+  test.done()
+
+module.exports.numeric12Bytes = (test) ->
+  colMetaData = [
+    type: dataTypeByName.NumericN
+    precision: 23
+    scale: 1
+  ]
+
+  value = ((0x100000000 * 0x100000000) + 0x200000000 + 93) / 10
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeUInt8(1 + 12)
+  buffer.writeUInt8(1)      # positive
+  buffer.writeUInt32LE(93)
+  buffer.writeUInt32LE(2)
+  buffer.writeUInt32LE(1)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+
+  test.done()
+
+module.exports.numeric16Bytes = (test) ->
+  colMetaData = [
+    type: dataTypeByName.NumericN
+    precision: 33
+    scale: 1
+  ]
+
+  value = ((0x100000000 * 0x100000000 * 0x100000000) + (0x200000000 * 0x100000000) + 0x300000000 + 93) / 10
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeUInt8(1 + 16)
+  buffer.writeUInt8(1)      # positive
+  buffer.writeUInt32LE(93)
+  buffer.writeUInt32LE(3)
+  buffer.writeUInt32LE(2)
+  buffer.writeUInt32LE(1)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, value)
+
+  test.done()
+
+module.exports.numericNull = (test) ->
+  colMetaData = [
+    type: dataTypeByName.NumericN
+    precision: 3
+    scale: 1
+  ]
+
+  buffer = new WritableTrackingBuffer(0, 'ucs2')
+  buffer.writeUInt8(0xD1)
+
+  buffer.writeUInt8(0)
+  #console.log(buffer)
+
+  parser = new Parser({}, colMetaData, options)
+  parser.write(buffer.data)
+  token = parser.read()
+  #console.log(token)
+
+  test.strictEqual(token.columns.length, 1)
+  test.strictEqual(token.columns[0].value, null)
+
+  test.done()

--- a/test/unit/token/streaming/sspi-token-parser-test.coffee
+++ b/test/unit/token/streaming/sspi-token-parser-test.coffee
@@ -1,0 +1,44 @@
+SSPIParser = require('../../../src/token/sspi-token-parser')
+ReadBuffer = require( '../../../src/tracking-buffer/readable-tracking-buffer')
+WriteBuffer = require( '../../../src/tracking-buffer/writable-tracking-buffer')
+
+exports.parseChallenge = (test) ->
+    source = new WriteBuffer(67)
+    source.copyFrom(new Buffer([0x00,0x00,0x00]))
+    source.writeString('NTLMSSP\0', 'utf8')
+    source.writeInt32LE(2) # message type
+    source.writeInt16LE(12) # domain len
+    source.writeInt16LE(12) # domain max
+    source.writeInt32LE(111) # domain offset
+    source.writeInt32LE(11256099) # flags == 'abc123'
+    source.copyFrom(new Buffer([0xa1,0xb2,0xc3,0xd4,0xe5,0xf6,0xa7,0xb8])) # nonce
+    source.copyFrom(new Buffer([0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00])) # empty
+    source.writeInt16LE(4) # target len
+    source.writeInt16LE(4) # target max
+    source.writeInt32LE(222) # target offset
+    source.copyFrom(new Buffer([0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08])) # odd data
+    source.writeString('domain', 'ucs2') # domain
+    source.writeInt32BE(11259375) # target == 'abcdef'
+
+    readable = new ReadBuffer(source.data)
+    challenge = SSPIParser(readable)
+
+    expected = 
+        magic: 'NTLMSSP\0'
+        type: 2
+        domainLen: 12
+        domainMax: 12
+        domainOffset: 111
+        flags: 11256099
+        nonce: new Buffer([0xa1,0xb2,0xc3,0xd4,0xe5,0xf6,0xa7,0xb8])
+        zeroes: new Buffer([0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00])
+        targetLen: 4
+        targetMax: 4
+        targetOffset: 222
+        oddData: new Buffer([0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08])
+        domain: 'domain'
+        target: new Buffer([0x00, 0xab, 0xcd, 0xef])
+
+    test.deepEqual(challenge.ntlmpacket, expected)
+    
+    test.done()

--- a/test/unit/token/streaming/token-stream-parser-test.coffee
+++ b/test/unit/token/streaming/token-stream-parser-test.coffee
@@ -1,0 +1,57 @@
+Debug = require('../../../src/debug')
+Parser = require('../../../src/token/token-stream-parser').Parser
+TYPE = require('../../../src/token/token').TYPE
+WritableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+debug = new Debug({token: true})
+
+module.exports.envChange = (test) ->
+  test.expect(2)
+
+  buffer = createDbChangeBuffer()
+
+  parser = new Parser(debug)
+  parser.on('databaseChange', (event) ->
+    test.ok(event)
+  )
+
+  parser.addBuffer(buffer)
+
+  test.ok(parser.isEnd())
+
+  test.done()
+
+module.exports.tokenSplitAcrossBuffers = (test) ->
+  test.expect(2)
+
+  buffer = createDbChangeBuffer()
+
+  parser = new Parser(debug)
+  parser.on('databaseChange', (event) ->
+      test.ok(event)
+  )
+
+  parser.addBuffer(buffer.slice(0,6))
+  parser.addBuffer(buffer.slice(6))
+
+  test.ok(parser.isEnd())
+
+  test.done()
+
+createDbChangeBuffer = ->
+  oldDb = 'old'
+  newDb = 'new'
+  buffer = new WritableTrackingBuffer(50, 'ucs2')
+
+  buffer.writeUInt8(TYPE.ENVCHANGE)
+  buffer.writeUInt16LE(0)                 # Length written later
+  buffer.writeUInt8(0x01)                 # Database
+  buffer.writeUInt8(newDb.length)
+  buffer.writeString(newDb)
+  buffer.writeUInt8(oldDb.length)
+  buffer.writeString(oldDb)
+
+  buffer.data.writeUInt16LE(buffer.data.length - (1 + 2), 1);
+  #console.log(buffer)
+
+  buffer.data


### PR DESCRIPTION
This replaces the token parser inside tedious with a stream based version based on the [dissolve](https://github.com/deoxxa/dissolve) module.

This is pretty much a big ugly hack at the moment, but it passes all tedious unit and integration tests. (Also, the application I'm working on passes all it's tests with the new parser). Beware, here be dragons.

The idea behind these changes is to make the token parsing code more performant. Right now, if a token is split over multiple tds messages, parsing is retried each time a new message is received from scratch. Obviously, this results in incredibly bad performance.

The `dissolve` module gives us a way to do chunk based parsing of tokens, without having to throw away the parsing results even in the case that tokens span multiple packages.

Here's some performance numbers (see `benchmarks/benchmarks.coffee`):

### Old Parser

```
$ node_modules/.bin/coffee benchmarks/query.coffee
Benchmarking 'nvarchar (small)'
nvarchar (small) x 68.06 ops/sec ±0.32% (22 runs sampled)
Memory: 5.4609375
Benchmarking 'nvarchar (large)'
nvarchar (large) x 1.84 ops/sec ±1.45% (14 runs sampled)
Memory: 19.265625
Benchmarking 'varbinary (small)'
varbinary (small) x 66.09 ops/sec ±0.14% (14 runs sampled)
Memory: 3.6171875
Benchmarking 'varbinary (large)'
varbinary (large) x 1.89 ops/sec ±1.64% (14 runs sampled)
Memory: 242.21484375
Benchmarking 'varbinary (huge)'
varbinary (huge) x 0.02 ops/sec ±9.94% (5 runs sampled)
Memory: 324.49609375
Done!
```

### New Parser

```
$ node_modules/.bin/coffee benchmarks/query.coffee
Benchmarking 'nvarchar (small)'
nvarchar (small) x 69.67 ops/sec ±0.50% (29 runs sampled)
Memory: 7.828125
Benchmarking 'nvarchar (large)'
nvarchar (large) x 7.01 ops/sec ±1.82% (37 runs sampled)
Memory: 31.6328125
Benchmarking 'varbinary (small)'
varbinary (small) x 65.99 ops/sec ±0.19% (13 runs sampled)
Memory: 6.296875
Benchmarking 'varbinary (large)'
varbinary (large) x 8.09 ops/sec ±2.41% (41 runs sampled)
Memory: 51.69140625
Benchmarking 'varbinary (huge)'
varbinary (huge) x 0.80 ops/sec ±1.13% (8 runs sampled)
Memory: 276.75390625
Done!
```

As you can see, the switch to `dissolve` hugely improves the performance when receiving data that spans multiple tds messages, while not impacting the performance of data that is contained inside a single message.

There is a slight increase in the memory usage reported in the benchmarks, and I'm not really sure what is causing this, but I'll take a closer look.

Overall, this is definitely not ready yet, but is meant to show off some of the work I've been doing and to gather some feedback on this.