### PR TITLE
Fix #207 - Resolve issues with Login7 Payload

### DIFF
--- a/src/login7-payload.coffee
+++ b/src/login7-payload.coffee
@@ -249,6 +249,7 @@ class Login7Payload
 
   createNTLMRequest: (options) ->
     domain = escape(options.domain.toUpperCase())
+    workstation = escape( if options.workstation then options.workstation.toUpperCase() else '')
     protocol = 'NTLMSSP\u0000'
     BODY_LENGTH = 40
     type1flags = @getNTLMFlags()
@@ -259,6 +260,9 @@ class Login7Payload
     buffer.writeUInt32LE(type1flags) # TYPE1 flag
     buffer.writeUInt16LE(domain.length) # domain length
     buffer.writeUInt16LE(domain.length) # domain max length
+    buffer.writeUInt32LE(BODY_LENGTH + workstation.length) # domain buffer offset
+    buffer.writeUInt16LE(workstation.length) # workstation length
+    buffer.writeUInt16LE(workstation.length) # workstation max length
     buffer.writeUInt32LE(BODY_LENGTH) # domain buffer offset
     buffer.writeUInt8(5) #ProductMajorVersion
     buffer.writeUInt8(0) #ProductMinorVersion
@@ -267,6 +271,7 @@ class Login7Payload
     buffer.writeUInt8(0) #VersionReserved2
     buffer.writeUInt8(0) #VersionReserved3
     buffer.writeUInt8(15) #NTLMRevisionCurrent
+    buffer.writeString(workstation, 'ascii')
     buffer.writeString(domain, 'ascii')
     buffer.data
 
@@ -288,14 +293,14 @@ class Login7Payload
     password
 
   getNTLMFlags: ->
-    (NTLMFlags.NTLM_NegotiateUnicode + 
-    NTLMFlags.NTLM_NegotiateOEM + 
-    NTLMFlags.NTLM_RequestTarget + 
-    NTLMFlags.NTLM_NegotiateNTLM + 
-    NTLMFlags.NTLM_NegotiateOemDomainSupplied + 
-    NTLMFlags.NTLM_NegotiateAlwaysSign + 
-    NTLMFlags.NTLM_NegotiateVersion + 
-    NTLMFlags.NTLM_Negotiate128 + 
+    (NTLMFlags.NTLM_NegotiateUnicode +
+    NTLMFlags.NTLM_NegotiateOEM +
+    NTLMFlags.NTLM_RequestTarget +
+    NTLMFlags.NTLM_NegotiateNTLM +
+    NTLMFlags.NTLM_NegotiateOemDomainSupplied +
+    NTLMFlags.NTLM_NegotiateAlwaysSign +
+    NTLMFlags.NTLM_NegotiateVersion +
+    NTLMFlags.NTLM_Negotiate128 +
     NTLMFlags.NTLM_Negotiate56)
 
   toString: (indent) ->

--- a/src/login7-payload.coffee
+++ b/src/login7-payload.coffee
@@ -253,6 +253,7 @@ class Login7Payload
     protocol = 'NTLMSSP\u0000'
     BODY_LENGTH = 40
     type1flags = @getNTLMFlags()
+    type1flags -= NTLMFlags.NTLM_NegotiateOemWorkstationSupplied if workstation is ''
     bufferLength = BODY_LENGTH + domain.length
     buffer = new WritableTrackingBuffer(bufferLength)
     buffer.writeString(protocol, 'utf8') # protocol
@@ -298,8 +299,10 @@ class Login7Payload
     NTLMFlags.NTLM_RequestTarget +
     NTLMFlags.NTLM_NegotiateNTLM +
     NTLMFlags.NTLM_NegotiateOemDomainSupplied +
+    NTLMFlags.NTLM_NegotiateOemWorkstationSupplied +
     NTLMFlags.NTLM_NegotiateAlwaysSign +
     NTLMFlags.NTLM_NegotiateVersion +
+    NTLMFlags.NTLM_NegotiateExtendedSecurity +
     NTLMFlags.NTLM_Negotiate128 +
     NTLMFlags.NTLM_Negotiate56)
 

--- a/src/login7-payload.coffee
+++ b/src/login7-payload.coffee
@@ -249,7 +249,7 @@ class Login7Payload
 
   createNTLMRequest: (options) ->
     domain = escape(options.domain.toUpperCase())
-    workstation = escape( if options.workstation then options.workstation.toUpperCase() else '')
+    workstation = if options.workstation then escape( options.workstation.toUpperCase() ) else ''
     protocol = 'NTLMSSP\u0000'
     BODY_LENGTH = 40
     type1flags = @getNTLMFlags()

--- a/test/unit/login7-payload-test.coffee
+++ b/test/unit/login7-payload-test.coffee
@@ -55,6 +55,7 @@ exports.createNTLM = (test) ->
     appName: 'app'
     serverName: 'server'
     domain: 'domain'
+    workstation: 'workstation'
     language: 'lang'
     database: 'db'
     packetSize: 1024
@@ -84,6 +85,9 @@ exports.createNTLM = (test) ->
 
   protocolHeader = payload.ntlmPacket.slice(0, 8).toString('utf8')
   test.strictEqual(protocolHeader, 'NTLMSSP\u0000')
+
+  workstationName = payload.ntlmPacket.slice(payload.ntlmPacket.length - 17).toString('ascii').substr( 0, 11 )
+  test.strictEqual(workstationName, 'WORKSTATION')
 
   domainName = payload.ntlmPacket.slice(payload.ntlmPacket.length - 6).toString('ascii')
   test.strictEqual(domainName, 'DOMAIN')


### PR DESCRIPTION
This should resolve both #207 and #214. After this fix, I was able to connect to a SQL Server on an AD machine using AD credentials from both OS X and Ubuntu machines that were not members of the AD domain. Planning on further integration testing, but wanted to  get the conversation started. (cc @bretcope, @rossipedia)