### PR TITLE
Set ansi_null_dflt_on on by default

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -277,6 +277,7 @@ class Connection extends EventEmitter
     @config.options.useColumnNames ?= false
     @config.options.connectionIsolationLevel ||= ISOLATION_LEVEL.READ_COMMITTED
     @config.options.readOnlyIntent ?= false
+    @config.options.enableAnsiNullDefault ?= true
 
     if !@config.options.port && !@config.options.instanceName
       @config.options.port = DEFAULT_PORT
@@ -675,6 +676,7 @@ class Connection extends EventEmitter
 
   getInitialSql: ->
     xact_abort = if @config.options.abortTransactionOnError then 'on' else 'off'
+    enableAnsiNullDefault = if @config.options.enableAnsiNullDefault then 'on' else 'off'
     """set textsize #{@config.options.textsize}
 set quoted_identifier on
 set arithabort off
@@ -682,6 +684,7 @@ set numeric_roundabort off
 set ansi_warnings on
 set ansi_padding on
 set ansi_nulls on
+set ansi_null_dflt_on #{enableAnsiNullDefault}
 set concat_null_yields_null on
 set cursor_close_on_commit off
 set implicit_transactions off

--- a/test/integration/errors-test.coffee
+++ b/test/integration/errors-test.coffee
@@ -31,11 +31,11 @@ exports.uniqueConstraint = (test) ->
     test.ok(err instanceof Error)
     test.strictEqual(err.number, 2627)
     
-exports.ansiNullDefaults = (test) ->
+exports.nullable = (test) ->
   sql = """
-  create table #testAnsiNullDefault (id int);
-  insert #testAnsiNullDefault values (null);
-  drop table #testAnsiNullDefault;
+  create table #testNullable (id int not null);
+  insert #testNullable values (null);
+  drop table #testNullable;
   """
 
   test.expect(3)


### PR DESCRIPTION
I recently switched my application to use `tedious` for connecting to SQL Server 2012, which mostly went smoothly. I did however notice that some stored procedures produced errors when ran through a `tedious` connection, when they worked when run via ODBC or SQL Server Management Studio.

By playing with the Query Options in SSMS I was able to find that I could reproduce the problem by unticking `SET ANSI_NULL_DFLT_ON`. According to [MSDN](http://msdn.microsoft.com/en-us/library/ms187375.aspx) the OLE DB and ODBC drivers set this flag by default. Perhaps `tedious` should set it too?

At the same time, perhaps a way of customizing what `getInitialSql` returns would be useful, but I thought that wasn't really for me to decide. For the moment, I have duck-punched it like this: 
```coffeescript
oldInitialSql = Connection::getInitialSql
Connection::getInitialSql = ->
    sql = oldInitialSql.call(this)
    "#{sql}
    set ansi_null_dflt_on on"
```