### PR TITLE
Add error.number property and some simple tests for its correctness.

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -311,6 +311,11 @@ class Connection extends EventEmitter
         if @request
           @request.error = RequestError token.message, 'EREQUEST'
           @request.error.number = token.number
+          @request.error.state = token.state
+          @request.error.class = token.class
+          @request.error.serverName = token.serverName
+          @request.error.procName = token.procName
+          @request.error.lineNumber = token.lineNumber
       else
         @loginError = ConnectionError token.message, 'ELOGIN'
     )

--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -310,6 +310,7 @@ class Connection extends EventEmitter
       if @loggedIn
         if @request
           @request.error = RequestError token.message, 'EREQUEST'
+          @request.error.number = token.number
       else
         @loginError = ConnectionError token.message, 'ELOGIN'
     )

--- a/test/integration/datatypes-in-results-test.coffee
+++ b/test/integration/datatypes-in-results-test.coffee
@@ -304,7 +304,7 @@ execSql = (test, sql, expectedValue, tdsVersion) ->
   if tdsVersion and tdsVersion > config.options.tdsVersion
   	return test.done()
 
-  test.expect(2)
+  test.expect(3)
 
   request = new Request(sql, (err) ->
     test.ifError(err)
@@ -324,10 +324,8 @@ execSql = (test, sql, expectedValue, tdsVersion) ->
   connection = new Connection(config)
 
   connection.on('connect', (err) ->
-    if (err)
-      console.log err
-    else
-      connection.execSqlBatch(request)
+    test.ifError(err)
+    connection.execSqlBatch(request)
   )
 
   connection.on('end', (info) ->

--- a/test/integration/errors-test.coffee
+++ b/test/integration/errors-test.coffee
@@ -1,0 +1,73 @@
+async = require('async')
+Connection = require('../../src/connection')
+Request = require('../../src/request')
+fs = require('fs')
+
+debug = false
+
+config = JSON.parse(fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')).config
+config.options.textsize = 8 * 1024
+
+if (debug)
+  config.options.debug =
+    packet: true
+    data: true
+    payload: true
+    token: true
+    log: true
+else
+  config.options.debug = {}
+
+exports.uniqueConstraint = (test) ->
+  sql = """
+  create table #testUnique (id int unique);
+  insert #testUnique values (1), (2), (3);
+  insert #testUnique values (2);
+  drop table #testUnique;
+  """
+
+  test.expect(2)
+  execSql test, sql, (err) ->
+    test.ok(err instanceof Error)
+    test.strictEqual(err.number, 2627)
+    
+exports.ansiNullDefaults = (test) ->
+  sql = """
+  create table #testAnsiNullDefault (id int);
+  insert #testAnsiNullDefault values (null);
+  drop table #testAnsiNullDefault;
+  """
+
+  test.expect(2)
+  execSql test, sql, (err) ->
+    test.ok(err instanceof Error)
+    test.strictEqual(err.number, 515)
+    
+exports.cannotDropProcedure = (test) ->
+  sql = """
+  drop procedure #nonexistentProcedure;
+  """
+
+  test.expect(2)
+  execSql test, sql, (err) ->
+    test.ok(err instanceof Error)
+    test.strictEqual(err.number, 3701)
+
+execSql = (test, sql, requestCallback) ->
+  connection = new Connection(config)
+
+  request = new Request sql, ->
+    requestCallback.apply this, arguments
+    connection.close()
+
+  connection.on 'connect', (err) ->
+    if (err)
+      console.log err
+    else
+      connection.execSqlBatch(request)
+
+  connection.on 'end', (info) ->
+    test.done()
+
+  if debug 
+    connection.on 'debug', (message) -> console.log(message)

--- a/test/integration/errors-test.coffee
+++ b/test/integration/errors-test.coffee
@@ -62,7 +62,7 @@ exports.extendedErrorInfo = (test) ->
 
   test.expect(9)
 
-  execProc = new Request "#divideByZero", (err) ->
+  execProc = new Request "#testExtendedErrorInfo", (err) ->
     test.ok(err instanceof Error)
 
     test.strictEqual(err.number, 50000)
@@ -73,13 +73,13 @@ exports.extendedErrorInfo = (test) ->
 
     # The procedure name will actually be padded to 128 chars with underscores and
     # some random hexadecimal digits.
-    test.ok(err.procName?.indexOf("#divideByZero") == 0,
-      "err.procName should begin with #divideByZero, was actually #{err.procName}")
+    test.ok(err.procName?.indexOf("#testExtendedErrorInfo") == 0,
+      "err.procName should begin with #testExtendedErrorInfo, was actually #{err.procName}")
     test.strictEqual(err.lineNumber, 1, "err.lineNumber should be 1")
       
     connection.close()
 
-  createProc = new Request "create procedure #divideByZero as raiserror('test error message', 14, 42)", (err) ->
+  createProc = new Request "create procedure #testExtendedErrorInfo as raiserror('test error message', 14, 42)", (err) ->
     test.ifError(err)
     connection.callProcedure execProc
 

--- a/test/integration/errors-test.coffee
+++ b/test/integration/errors-test.coffee
@@ -53,6 +53,46 @@ exports.cannotDropProcedure = (test) ->
     test.ok(err instanceof Error)
     test.strictEqual(err.number, 3701)
 
+# Create a temporary stored procedure to test that err.procName and
+# err.lineNumber are correct.
+# We can't really test much else reliably, other than that they exist.
+exports.extendedErrorInfo = (test) ->
+  connection = new Connection(config)
+
+  test.expect(9)
+
+  execProc = new Request "#divideByZero", (err) ->
+    test.ok(err instanceof Error)
+    test.strictEqual(err.number, 8134)
+      
+    # It doesn't look like there's any guarantee that error state values
+    # will be kept the same across different versions of SQL Server, so
+    # it's probably best to just test that it's not null.
+    test.ok(err.state?, "err.state not set")
+    test.ok(err.class?, "err.class not set")
+    test.ok(err.serverName?, "err.serverName not set")
+    # The procedure name will actually be padded to 128 chars with underscores and
+    # some random hexadecimal digits.
+    test.ok(err.procName?.indexOf("#divideByZero") == 0,
+      "err.procName should begin with #divideByZero, was actually #{err.procName}")
+    test.strictEqual(err.lineNumber, 1, "err.lineNumber should be 1")
+      
+    connection.close()
+
+  createProc = new Request "create procedure #divideByZero as select 1/0 as x", (err) ->
+    test.ifError(err)
+    connection.callProcedure execProc
+
+  connection.on 'connect', (err) ->
+    test.ifError(err)
+    connection.execSqlBatch(createProc)
+
+  connection.on 'end', (info) ->
+    test.done()
+
+  if debug 
+    connection.on 'debug', (message) -> console.log(message)
+
 execSql = (test, sql, requestCallback) ->
   connection = new Connection(config)
 

--- a/test/integration/parameterised-statements-test.coffee
+++ b/test/integration/parameterised-statements-test.coffee
@@ -255,7 +255,7 @@ exports.outputDateTimeNull = (test) ->
   execSqlOutput(test, TYPES.DateTime, null)
 
 exports.multipleParameters = (test) ->
-  test.expect(6)
+  test.expect(7)
 
   config = getConfig()
 
@@ -282,6 +282,7 @@ exports.multipleParameters = (test) ->
   connection = new Connection(config)
 
   connection.on('connect', (err) ->
+      test.ifError(err)
       connection.execSql(request)
   )
 
@@ -300,7 +301,7 @@ execSql = (test, type, value, tdsVersion, options) ->
   if tdsVersion and tdsVersion > config.options.tdsVersion
   	return test.done()
 
-  test.expect(5)
+  test.expect(6)
 
   request = new Request('select @param', (err) ->
       test.ifError(err)
@@ -331,6 +332,7 @@ execSql = (test, type, value, tdsVersion, options) ->
   connection = new Connection(config)
 
   connection.on('connect', (err) ->
+      test.ifError(err)
       connection.execSql(request)
   )
 
@@ -347,7 +349,7 @@ execSql = (test, type, value, tdsVersion, options) ->
   )
 
 execSqlOutput = (test, type, value) ->
-  test.expect(6)
+  test.expect(7)
 
   config = getConfig()
 
@@ -383,6 +385,7 @@ execSqlOutput = (test, type, value) ->
   connection = new Connection(config)
 
   connection.on('connect', (err) ->
+      test.ifError(err)
       connection.execSql(request)
   )
 

--- a/test/integration/prepare-execute-statements-test.coffee
+++ b/test/integration/prepare-execute-statements-test.coffee
@@ -16,7 +16,7 @@ getConfig = ->
   config
 
 exports.prepareExecute = (test) ->
-  test.expect(4)
+  test.expect(5)
   value = 8
 
   config = getConfig()
@@ -40,6 +40,7 @@ exports.prepareExecute = (test) ->
   )
 
   connection.on('connect', (err) ->
+    test.ifError(err)
     connection.prepare(request)
   )
 
@@ -52,7 +53,7 @@ exports.prepareExecute = (test) ->
   )
 
 exports.unprepare = (test) ->
-  test.expect(2)
+  test.expect(3)
 
   config = getConfig()
   prepared = false
@@ -70,6 +71,7 @@ exports.unprepare = (test) ->
   )
 
   connection.on('connect', (err) ->
+    test.ifError(err)
     connection.prepare(request)
   )
 

--- a/test/integration/tvp-test.coffee
+++ b/test/integration/tvp-test.coffee
@@ -24,7 +24,7 @@ getConfig = ->
   config
 
 exports.callProcedureWithTVP = (test) ->
-  test.expect(12)
+  test.expect(13)
 
   config = getConfig()
 
@@ -106,6 +106,7 @@ exports.callProcedureWithTVP = (test) ->
   connection = new Connection(config)
 
   connection.on('connect', (err) ->
+    test.ifError(err)
     connection.execSqlBatch(request)
   )
 


### PR DESCRIPTION
I've had a stab at a possible patch for #226 based on ashelley's fix, with some tests, since it's very relevant to my interests.

I wasn't sure about coding conventions - I don't usually add parentheses around function calls in coffeescript, especially when one of them is a callback, but not all the code seemed to agree on whether to do so or not.

Critique gratefully accepted!