### PR TITLE
Update connection.coffee

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -605,7 +605,7 @@ class Connection extends EventEmitter
       preloginPayload.toString('  ')
     )
 
-    if preloginPayload.encryptionString == 'ON'
+    if preloginPayload.encryptionString in ['ON','REQ']
       @dispatchEvent('tls')
     else
       @dispatchEvent('noTls')


### PR DESCRIPTION
Fixes #238 - Relates to #241

NOTE: when binding to the `secure` event, the connection still fails.

Special thank you to @christopheranderson and others at Microsoft Azure for digging into this issue.