### PR TITLE
Fix deprecation warning for #243.

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -648,7 +648,10 @@ class Connection extends EventEmitter
       payload.toString '  '
 
   initiateTlsSslHandshake: ->
-    credentials = tls.createSecureContext(@config.options.cryptoCredentialsDetails)
+    credentials = if tls.createSecureContext
+      tls.createSecureContext(@config.options.cryptoCredentialsDetails)
+    else
+      crypto.createCredentials(@config.options.cryptoCredentialsDetails)
     @securePair = tls.createSecurePair(credentials)
 
     @securePair.on('secure', =>

--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -648,7 +648,7 @@ class Connection extends EventEmitter
       payload.toString '  '
 
   initiateTlsSslHandshake: ->
-    credentials = crypto.createCredentials(@config.options.cryptoCredentialsDetails)
+    credentials = tls.createSecureContext(@config.options.cryptoCredentialsDetails)
     @securePair = tls.createSecurePair(credentials)
 
     @securePair.on('secure', =>


### PR DESCRIPTION
This addresses the issue described in #243.

It uses the `tls.createSecureContext` function instead of `crypto.createCredentials`.

Note - I wasn't sure how deprecations should be handled. The `tls.createSecureContext` function wasn't added until Node v0.11.14:

* http://nodejs.org/docs/v0.11.13/api/tls.html#tls_tls_createsecurecontext_details
* http://nodejs.org/docs/v0.11.14/api/tls.html#tls_tls_createsecurecontext_details

My first pull request, so let me know if I missed anything.