### PR TITLE
Integrated type checks

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -732,6 +732,11 @@ set xact_abort #{xact_abort}"""
 
   execSql: (request) ->
     request.transformIntoExecuteSqlRpc()
+    if request.error?
+      return process.nextTick =>
+        @debug.log request.error.message
+        request.callback request.error
+
     @makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, @currentTransactionDescriptor(), @config.options))
   
   newBulkLoad: (table, callback) ->
@@ -759,9 +764,20 @@ set xact_abort #{xact_abort}"""
 
   execute: (request, parameters) ->
     request.transformIntoExecuteRpc(parameters)
+    if request.error?
+      return process.nextTick =>
+        @debug.log request.error.message
+        request.callback request.error
+
     @makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, @currentTransactionDescriptor(), @config.options))
 
   callProcedure: (request) ->
+    request.validateParameters()
+    if request.error?
+      return process.nextTick =>
+        @debug.log request.error.message
+        request.callback request.error
+
     @makeRequest(request, TYPE.RPC_REQUEST, new RpcRequestPayload(request, @currentTransactionDescriptor(), @config.options))
 
   beginTransaction: (callback, name, isolationLevel) ->

--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -28,6 +28,12 @@ TYPE =
         buffer.writeUInt8(parseInt(parameter.value))
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      value = parseInt value
+      if isNaN value then return new TypeError "Invalid number."
+      if value < 0 or value > 255 then return new TypeError "Value must be between 0 and 255."
+      value
   0x32:
     type: 'BIT'
     name: 'Bit'
@@ -44,6 +50,9 @@ TYPE =
       else
         buffer.writeUInt8(1)
         buffer.writeUInt8(if parameter.value then 1 else 0)
+    validate: (value) ->
+      if not value? then return null
+      if value then true else false
   0x34:
     type: 'INT2'
     name: 'SmallInt'
@@ -60,6 +69,12 @@ TYPE =
         buffer.writeInt16LE(parseInt(parameter.value))
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      value = parseInt value
+      if isNaN value then return new TypeError "Invalid number."
+      if value < -32768 or value > 32767 then return new TypeError "Value must be between -32768 and 32767."
+      value
   0x38:
     type: 'INT4'
     name: 'Int'
@@ -76,6 +91,12 @@ TYPE =
         buffer.writeInt32LE(parseInt(parameter.value))
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      value = parseInt value
+      if isNaN value then return new TypeError "Invalid number."
+      if value < -2147483648 or value > 2147483647 then return new TypeError "Value must be between -2147483648 and 2147483647."
+      value
   0x3A:
     type: 'DATETIM4'
     name: 'SmallDateTime'
@@ -100,6 +121,12 @@ TYPE =
         buffer.writeUInt16LE(minutes)
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      if value instanceof Date then return value
+      value = Date.parse value
+      if isNaN value then return new TypeError "Invalid date."
+      value
   0x3B:
     type: 'FLT4'
     name: 'Real'
@@ -116,6 +143,11 @@ TYPE =
         buffer.writeFloatLE(parseFloat(parameter.value))
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      value = parseFloat value
+      if isNaN value then return new TypeError "Invalid number."
+      value
   0x3C:
     type: 'MONEY'
     name: 'Money'
@@ -132,6 +164,11 @@ TYPE =
         buffer.writeMoney parameter.value * 10000
       else
         buffer.writeUInt8 0
+    validate: (value) ->
+      if not value? then return null
+      value = parseFloat value
+      if isNaN value then return new TypeError "Invalid number."
+      value
   0x3D:
     type: 'DATETIME'
     name: 'DateTime'
@@ -165,6 +202,12 @@ TYPE =
         buffer.writeUInt32LE(threeHundredthsOfSecond)
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      if value instanceof Date then return value
+      value = Date.parse value
+      if isNaN value then return new TypeError "Invalid date."
+      value
   0x3E:
     type: 'FLT8'
     name: 'Float'
@@ -181,6 +224,11 @@ TYPE =
         buffer.writeDoubleLE(parseFloat(parameter.value))
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      value = parseFloat value
+      if isNaN value then return new TypeError "Invalid number."
+      value
   0x37:
     type: 'DECIMAL'
     name: 'Decimal'
@@ -243,6 +291,11 @@ TYPE =
           buffer.writeUInt32LE 0x00000000
       else
         buffer.writeUInt8 0
+    validate: (value) ->
+      if not value? then return null
+      value = parseFloat value
+      if isNaN value then return new TypeError "Invalid number."
+      value
   0x3F:
     type: 'NUMERIC'
     name: 'Numeric'
@@ -304,6 +357,11 @@ TYPE =
           buffer.writeUInt32LE 0x00000000
       else
         buffer.writeUInt8 0
+    validate: (value) ->
+      if not value? then return null
+      value = parseFloat value
+      if isNaN value then return new TypeError "Invalid number."
+      value
   0x7A:
     type: 'MONEY4'
     name: 'SmallMoney'
@@ -320,6 +378,12 @@ TYPE =
         buffer.writeInt32LE parameter.value * 10000
       else
         buffer.writeUInt8 0
+    validate: (value) ->
+      if not value? then return null
+      value = parseFloat value
+      if isNaN value then return new TypeError "Invalid number."
+      if value < -214748.3648 or value > 214748.3647 then return new TypeError "Value must be between -214748.3648 and 214748.3647."
+      value
   0x7F:
     type: 'INT8'
     name: 'BigInt'
@@ -337,6 +401,9 @@ TYPE =
         buffer.writeInt64LE(val)
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      value
 
   # Variable-length types
   0x22:
@@ -365,6 +432,10 @@ TYPE =
         # buffer.writePLPBody parameter.value
       else
         buffer.writeInt32LE parameter.length
+    validate: (value) ->
+      if not value? then return null
+      if not Buffer.isBuffer value then return new TypeError "Invalid buffer."
+      value
       
   0x23:
     type: 'TEXT'
@@ -394,6 +465,12 @@ TYPE =
         buffer.writeString(parameter.value.toString(), 'ascii')
       else
         buffer.writeInt32LE(parameter.length)
+    validate: (value) ->
+      if not value? then return null
+      if typeof value isnt 'string'
+        if typeof value.toString isnt 'function' then return TypeError "Invalid string."
+        value = value.toString()
+      value
   0x24:
     type: 'GUIDN'
     name: 'UniqueIdentifierN'
@@ -414,6 +491,12 @@ TYPE =
         buffer.writeBuffer(new Buffer(guidParser.guidToArray(parameter.value)))
       else
         buffer.writeUInt8(0)
+    validate: (value) ->
+      if not value? then return null
+      if typeof value isnt 'string'
+        if typeof value.toString isnt 'function' then return TypeError "Invalid string."
+        value = value.toString()
+      value
   0x26:
     type: 'INTN'
     name: 'IntN'
@@ -502,6 +585,10 @@ TYPE =
           # PLP_NULL
           buffer.writeUInt32LE(0xFFFFFFFF)
           buffer.writeUInt32LE(0xFFFFFFFF)
+    validate: (value) ->
+      if not value? then return null
+      if not Buffer.isBuffer value then return new TypeError "Invalid buffer."
+      value
         
   0xA7:
     type: 'BIGVARCHR'
@@ -556,6 +643,12 @@ TYPE =
           # PLP_NULL
           buffer.writeUInt32LE(0xFFFFFFFF)
           buffer.writeUInt32LE(0xFFFFFFFF)
+    validate: (value) ->
+      if not value? then return null
+      if typeof value isnt 'string'
+        if typeof value.toString isnt 'function' then return TypeError "Invalid string."
+        value = value.toString()
+      value
   0xAD:
     type: 'BIGBinary'
     name: 'Binary'
@@ -579,7 +672,10 @@ TYPE =
         buffer.writeBuffer parameter.value.slice 0, Math.min(parameter.length, @maximumLength)
       else
         buffer.writeUInt16LE NULL
-      
+    validate: (value) ->
+      if not value? then return null
+      if not Buffer.isBuffer value then return new TypeError "Invalid buffer."
+      value
   0xAF:
     type: 'BIGCHAR'
     name: 'Char'
@@ -619,6 +715,12 @@ TYPE =
         buffer.writeUsVarbyte parameter.value, 'ascii'
       else
         buffer.writeUInt16LE NULL
+    validate: (value) ->
+      if not value? then return null
+      if typeof value isnt 'string'
+        if typeof value.toString isnt 'function' then return TypeError "Invalid string."
+        value = value.toString()
+      value
   0xE7:
     type: 'NVARCHAR'
     name: 'NVarChar'
@@ -672,6 +774,12 @@ TYPE =
           # PLP_NULL
           buffer.writeUInt32LE(0xFFFFFFFF)
           buffer.writeUInt32LE(0xFFFFFFFF)
+    validate: (value) ->
+      if not value? then return null
+      if typeof value isnt 'string'
+        if typeof value.toString isnt 'function' then return TypeError "Invalid string."
+        value = value.toString()
+      value
   0xEF:
     type: 'NCHAR'
     name: 'NChar'
@@ -711,6 +819,12 @@ TYPE =
         buffer.writeUsVarbyte parameter.value, 'ucs2'
       else
         buffer.writeUInt16LE NULL
+    validate: (value) ->
+      if not value? then return null
+      if typeof value isnt 'string'
+        if typeof value.toString isnt 'function' then return TypeError "Invalid string."
+        value = value.toString()
+      value
   0xF1:
     type: 'XML'
     name: 'Xml'
@@ -761,7 +875,12 @@ TYPE =
             buffer.writeUInt40LE time
       else
         buffer.writeUInt8 0
-        
+    validate: (value) ->
+      if not value? then return null
+      if value instanceof Date then return value
+      value = Date.parse value
+      if isNaN value then return new TypeError "Invalid time."
+      value
   0x28:
     type: 'DATEN'
     name: 'DateN'
@@ -780,6 +899,12 @@ TYPE =
         buffer.writeUInt24LE Math.floor (+parameter.value - YEAR_ONE) / 86400000
       else
         buffer.writeUInt8 0
+    validate: (value) ->
+      if not value? then return null
+      if value instanceof Date then return value
+      value = Date.parse value
+      if isNaN value then return new TypeError "Invalid time."
+      value
   0x2A:
     type: 'DATETIME2N'
     name: 'DateTime2N'
@@ -829,6 +954,12 @@ TYPE =
         buffer.writeUInt24LE Math.floor (+parameter.value - YEAR_ONE) / 86400000
       else
         buffer.writeUInt8 0
+    validate: (value) ->
+      if not value? then return null
+      if value instanceof Date then return value
+      value = Date.parse value
+      if isNaN value then return new TypeError "Invalid time."
+      value
   0x2B:
     type: 'DATETIMEOFFSETN'
     name: 'DateTimeOffsetN'
@@ -882,7 +1013,12 @@ TYPE =
         buffer.writeInt16LE offset
       else
         buffer.writeUInt8 0
-  # ---
+    validate: (value) ->
+      if not value? then return null
+      if value instanceof Date then return value
+      value = Date.parse value
+      if isNaN value then return new TypeError "Invalid time."
+      value
   0xF0:
     type: 'UDTTYPE'
     name: 'UDT'
@@ -937,6 +1073,12 @@ TYPE =
 
       # TVP_NULL_TOKEN
       buffer.writeUInt8 0x00
+    validate: (value) ->
+      if not value? then return null
+      if typeof value isnt 'object' then return new TypeError "Invalid table."
+      if not Array.isArray value.columns then return new TypeError "Invalid table."
+      if not Array.isArray value.rows then return new TypeError "Invalid table."
+      value
 
 # Types not (yet) supported
 ###

--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -903,7 +903,7 @@ TYPE =
       if not value? then return null
       if value instanceof Date then return value
       value = Date.parse value
-      if isNaN value then return new TypeError "Invalid time."
+      if isNaN value then return new TypeError "Invalid date."
       value
   0x2A:
     type: 'DATETIME2N'
@@ -958,7 +958,7 @@ TYPE =
       if not value? then return null
       if value instanceof Date then return value
       value = Date.parse value
-      if isNaN value then return new TypeError "Invalid time."
+      if isNaN value then return new TypeError "Invalid date."
       value
   0x2B:
     type: 'DATETIMEOFFSETN'
@@ -1017,7 +1017,7 @@ TYPE =
       if not value? then return null
       if value instanceof Date then return value
       value = Date.parse value
-      if isNaN value then return new TypeError "Invalid time."
+      if isNaN value then return new TypeError "Invalid date."
       value
   0xF0:
     type: 'UDTTYPE'

--- a/test/unit/validations.coffee
+++ b/test/unit/validations.coffee
@@ -1,0 +1,380 @@
+TYPE = require('../../src/data-type').typeByName
+
+exports.Bit = (test) ->
+  value = TYPE.Bit.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Bit.validate true
+  test.strictEqual value, true
+  
+  value = TYPE.Bit.validate "asdf"
+  test.strictEqual value, true
+  
+  value = TYPE.Bit.validate ""
+  test.strictEqual value, false
+  
+  value = TYPE.Bit.validate 55
+  test.strictEqual value, true
+  
+  value = TYPE.Bit.validate 0
+  test.strictEqual value, false
+
+  test.done()
+  
+exports.TinyInt = (test) ->
+  value = TYPE.TinyInt.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.TinyInt.validate 15
+  test.strictEqual value, 15
+  
+  value = TYPE.TinyInt.validate "15"
+  test.strictEqual value, 15
+  
+  value = TYPE.TinyInt.validate 256
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.SmallInt = (test) ->
+  value = TYPE.SmallInt.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.SmallInt.validate -32768
+  test.strictEqual value, -32768
+  
+  value = TYPE.SmallInt.validate -32769
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Int = (test) ->
+  value = TYPE.Int.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Int.validate 2147483647
+  test.strictEqual value, 2147483647
+  
+  value = TYPE.Int.validate 2147483648
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.BigInt = (test) ->
+  value = TYPE.BigInt.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.BigInt.validate 2147483647
+  test.strictEqual value, 2147483647
+
+  test.done()
+
+exports.SmallDateTime = (test) ->
+  value = TYPE.SmallDateTime.validate null
+  test.strictEqual value, null
+  
+  date = new Date()
+  value = TYPE.SmallDateTime.validate date
+  test.strictEqual +value, +date
+  
+  value = TYPE.SmallDateTime.validate "2015-02-12T16:43:13.632Z"
+  test.strictEqual +value, 1423759393632
+  
+  value = TYPE.SmallDateTime.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.DateTime = (test) ->
+  value = TYPE.DateTime.validate null
+  test.strictEqual value, null
+  
+  date = new Date()
+  value = TYPE.DateTime.validate date
+  test.strictEqual +value, +date
+  
+  value = TYPE.DateTime.validate "2015-02-12T16:43:13.632Z"
+  test.strictEqual +value, 1423759393632
+  
+  value = TYPE.DateTime.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.DateTime = (test) ->
+  value = TYPE.DateTime.validate null
+  test.strictEqual value, null
+  
+  date = new Date()
+  value = TYPE.DateTime.validate date
+  test.strictEqual +value, +date
+  
+  value = TYPE.DateTime.validate "2015-02-12T16:43:13.632Z"
+  test.strictEqual +value, 1423759393632
+  
+  value = TYPE.DateTime.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.DateTime2 = (test) ->
+  value = TYPE.DateTime2.validate null
+  test.strictEqual value, null
+  
+  date = new Date()
+  value = TYPE.DateTime2.validate date
+  test.strictEqual +value, +date
+  
+  value = TYPE.DateTime2.validate "2015-02-12T16:43:13.632Z"
+  test.strictEqual +value, 1423759393632
+  
+  value = TYPE.DateTime2.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Time = (test) ->
+  value = TYPE.Time.validate null
+  test.strictEqual value, null
+  
+  date = new Date()
+  value = TYPE.Time.validate date
+  test.strictEqual +value, +date
+  
+  value = TYPE.Time.validate "2015-02-12T16:43:13.632Z"
+  test.strictEqual +value, 1423759393632
+  
+  value = TYPE.Time.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.DateTimeOffset = (test) ->
+  value = TYPE.DateTimeOffset.validate null
+  test.strictEqual value, null
+  
+  date = new Date()
+  value = TYPE.DateTimeOffset.validate date
+  test.strictEqual +value, +date
+  
+  value = TYPE.DateTimeOffset.validate "2015-02-12T16:43:13.632Z"
+  test.strictEqual +value, 1423759393632
+  
+  value = TYPE.DateTimeOffset.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Real = (test) ->
+  value = TYPE.Real.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Real.validate 1516.61556
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Real.validate "1516.61556"
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Real.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Float = (test) ->
+  value = TYPE.Float.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Float.validate 1516.61556
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Float.validate "1516.61556"
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Float.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Decimal = (test) ->
+  value = TYPE.Decimal.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Decimal.validate 1516.61556
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Decimal.validate "1516.61556"
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Decimal.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Numeric = (test) ->
+  value = TYPE.Numeric.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Numeric.validate 1516.61556
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Numeric.validate "1516.61556"
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Numeric.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Money = (test) ->
+  value = TYPE.Money.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Money.validate 1516.61556
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Money.validate "1516.61556"
+  test.strictEqual value, 1516.61556
+  
+  value = TYPE.Money.validate "xxx"
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.SmallMoney = (test) ->
+  value = TYPE.SmallMoney.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.SmallMoney.validate 214748.3647
+  test.strictEqual value, 214748.3647
+  
+  value = TYPE.SmallMoney.validate 214748.3648
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Image = (test) ->
+  value = TYPE.Image.validate null
+  test.strictEqual value, null
+  
+  buffer = new Buffer [0x00, 0x01]
+  value = TYPE.Image.validate buffer
+  test.strictEqual value, buffer
+  
+  value = TYPE.Image.validate {}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Binary = (test) ->
+  value = TYPE.Binary.validate null
+  test.strictEqual value, null
+  
+  buffer = new Buffer [0x00, 0x01]
+  value = TYPE.Binary.validate buffer
+  test.strictEqual value, buffer
+  
+  value = TYPE.Binary.validate {}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.VarBinary = (test) ->
+  value = TYPE.VarBinary.validate null
+  test.strictEqual value, null
+  
+  buffer = new Buffer [0x00, 0x01]
+  value = TYPE.VarBinary.validate buffer
+  test.strictEqual value, buffer
+  
+  value = TYPE.VarBinary.validate {}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Text = (test) ->
+  value = TYPE.Text.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Text.validate "asdf"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.Text.validate new Buffer "asdf", "utf8"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.Text.validate {toString: null}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.VarChar = (test) ->
+  value = TYPE.VarChar.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.VarChar.validate "asdf"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.VarChar.validate new Buffer "asdf", "utf8"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.VarChar.validate {toString: null}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.NVarChar = (test) ->
+  value = TYPE.NVarChar.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.NVarChar.validate "asdf"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.NVarChar.validate new Buffer "asdf", "utf8"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.NVarChar.validate {toString: null}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.Char = (test) ->
+  value = TYPE.Char.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.Char.validate "asdf"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.Char.validate new Buffer "asdf", "utf8"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.Char.validate {toString: null}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.NChar = (test) ->
+  value = TYPE.NChar.validate null
+  test.strictEqual value, null
+  
+  value = TYPE.NChar.validate "asdf"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.NChar.validate new Buffer "asdf", "utf8"
+  test.strictEqual value, "asdf"
+  
+  value = TYPE.NChar.validate {toString: null}
+  test.ok value instanceof TypeError
+
+  test.done()
+
+exports.TVP = (test) ->
+  value = TYPE.TVP.validate null
+  test.strictEqual value, null
+  
+  table = {columns: [], rows: []}
+  value = TYPE.TVP.validate table
+  test.strictEqual value, table
+  
+  value = TYPE.TVP.validate {}
+  test.ok value instanceof TypeError
+
+  test.done()


### PR DESCRIPTION
I finally found some time to finish integrated type validation. It's a basic set of validators that should prevent users seeing errors like `index out of range` or similar. It also adds basic type coercion, so `1` and `"1"` are both valid values for data type `Int`.

```javascript
request = new Request('select @name', function(err) {
    err instanceof RequestError
    err.code === "EPARAM"
    err.message === "Validation failed for parameter 'name'. Value must be between 0 and 255."
});
request.addParameter("name", TYPES.TinyInt, 999);
connection.execSql(request);
```

Type validation applies on `execSql`, `execute` and `callProcedure` methods.

Feature is based on #202 discussion.

I believe this can be merged without a problem, but I wanted to be absolutely sure I didn't forgot about anything so I opened this PR.