### PR TITLE
Refactor TLS Handling

### DIFF
--- a/src/message-io.coffee
+++ b/src/message-io.coffee
@@ -70,6 +70,12 @@ class MessageIO extends EventEmitter
     @securePair.encrypted.on 'data', (data) =>
       @sendMessage(TYPE.PRELOGIN, data)
 
+    # On Node >= 0.12, the encrypted stream automatically starts spewing out
+    # data once we attach a `data` listener. But on Node <= 0.10.x, this is not
+    # the case. We need to kick the cleartext stream once to get the
+    # encrypted end of the secure pair to emit the TLS handshake data.
+    @securePair.cleartext.write('')
+
   encryptAllFutureTraffic: () ->
     @socket.unpipe(@packetStream)
     @securePair.encrypted.removeAllListeners('data')


### PR DESCRIPTION
Right now, the TLS handling code is spread over both the `Connection` as well as the `MessageIO` classes. This PR is meant to amend this and bring all TLS handling code together into the `MessageIO` class.