### PR TITLE
Drop old node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - "0.6"
-  - "0.8"
   - "0.10"
   - "0.11"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/pekim/tedious.git"
   },
   "engines": {
-    "node": ">=0.6"
+    "node": ">= 0.10"
   },
   "dependencies": {
     "big-number": "0.3.1",


### PR DESCRIPTION
The last released version of 0.8 was in July 2014, and the last released version of 0.6 was somewhere in 2012. I think we can safely drop support for those.