### PR TITLE
Fix AppVeyor CI Flakiness

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,11 +29,14 @@ test_script:
 
       powershell %cd%\scripts\appveyor\config.ps1 SQL2008R2SP2
       npm run-script test-integration || SET EXITVAL=1
-
+      net stop MSSQL$SQL2008R2SP2
+      
       powershell %cd%\scripts\appveyor\config.ps1 SQL2012SP1
       npm run-script test-integration || SET EXITVAL=1
+      net stop MSSQL$SQL2012SP1
 
       powershell %cd%\scripts\appveyor\config.ps1 SQL2014
       npm run-script test-integration || SET EXITVAL=1
+      net stop MSSQL$SQL2014
 
       EXIT /B %EXITVAL%

--- a/scripts/appveyor/config.ps1
+++ b/scripts/appveyor/config.ps1
@@ -23,6 +23,7 @@ $config = @{
     options = @{
       port = $port;
       database = "master";
+      requestTimeout = 25000;
       cryptoCredentialsDetails = @{
         ciphers = "RC4-MD5"
       }


### PR DESCRIPTION
AppVeyor builds sometimes fail because requests fail to complete in the default request time of 15 seconds, so let's increase the timeout value a bit.