### PR TITLE
fix daylight saving issue for non utc dates

### DIFF
--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -2,7 +2,7 @@ guidParser = require('./guid-parser')
 NULL = (1 << 16) - 1
 EPOCH_DATE = new Date(1900, 0, 1)
 UTC_EPOCH_DATE = new Date(Date.UTC(1900, 0, 1))
-YEAR_ONE = new Date(2000, 0, -730118).getTime()
+YEAR_ONE = new Date(2000, 0, -730118)
 UTC_YEAR_ONE = Date.UTC(2000, 0, -730118)
 MAX = (1 << 16) - 1
 
@@ -114,7 +114,8 @@ TYPE =
           days = Math.floor (parameter.value.getTime() - UTC_EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
           minutes = (parameter.value.getUTCHours() * 60) + parameter.value.getUTCMinutes()
         else
-          days = Math.floor (parameter.value.getTime() - EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
+          dstDiff = -(parameter.value.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000
+          days = Math.floor (parameter.value.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24)
           minutes = (parameter.value.getHours() * 60) + parameter.value.getMinutes()
 
         buffer.writeUInt8(4)
@@ -189,7 +190,8 @@ TYPE =
           seconds += parameter.value.getUTCSeconds()
           milliseconds = (seconds * 1000) + parameter.value.getUTCMilliseconds()
         else
-          days = Math.floor (parameter.value.getTime() - EPOCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
+          dstDiff = -(parameter.value.getTimezoneOffset() - EPOCH_DATE.getTimezoneOffset()) * 60 * 1000
+          days = Math.floor (parameter.value.getTime() - EPOCH_DATE.getTime() + dstDiff) / (1000 * 60 * 60 * 24)
           seconds = parameter.value.getHours() * 60 * 60
           seconds += parameter.value.getMinutes() * 60
           seconds += parameter.value.getSeconds()
@@ -903,7 +905,8 @@ TYPE =
         if options.useUTC
           buffer.writeUInt24LE Math.floor (+parameter.value - UTC_YEAR_ONE) / 86400000
         else
-          buffer.writeUInt24LE Math.floor (+parameter.value - YEAR_ONE) / 86400000
+          dstDiff = -(parameter.value.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000
+          buffer.writeUInt24LE Math.floor (+parameter.value - YEAR_ONE + dstDiff) / 86400000
       else
         buffer.writeUInt8 0
     validate: (value) ->
@@ -964,7 +967,8 @@ TYPE =
         if options.useUTC
           buffer.writeUInt24LE Math.floor (+parameter.value - UTC_YEAR_ONE) / 86400000
         else
-          buffer.writeUInt24LE Math.floor (+parameter.value - YEAR_ONE) / 86400000
+          dstDiff = -(parameter.value.getTimezoneOffset() - YEAR_ONE.getTimezoneOffset()) * 60 * 1000
+          buffer.writeUInt24LE Math.floor (+parameter.value - YEAR_ONE + dstDiff) / 86400000
       else
         buffer.writeUInt8 0
     validate: (value) ->

--- a/test/unit/data-type.coffee
+++ b/test/unit/data-type.coffee
@@ -1,5 +1,6 @@
 TYPES = require('../../src/data-type')
 WritableTrackingBuffer = require('../../src/tracking-buffer/writable-tracking-buffer')
+ReadableTrackingBuffer = require('../../src/tracking-buffer/readable-tracking-buffer')
 
 exports.noTypeOverridesByAliases = (test) ->
   typesByName = {}
@@ -22,10 +23,10 @@ exports.knownAliases = (test) ->
 # Test date calculation for non utc date during daylight savings period
 exports.smallDateTimeDaylightSaving = (test) ->
   type = TYPES.typeByName['SmallDateTime']
-  for testSet in [[new Date('2015-06-18T23:59:59+0200'),42171],
-                  [new Date('2015-06-19T00:00:00+0200'),42172],
-                  [new Date('2015-06-19T23:59:59+0200'),42172],
-                  [new Date('2015-06-20T00:00:00+0200'),42173]]
+  for testSet in [[new Date('2015-06-18T21:59:59'),42171],
+                  [new Date('2015-06-18T22:00:00'),42172],
+                  [new Date('2015-06-19T21:59:59'),42172],
+                  [new Date('2015-06-19T22:00:00'),42173]]
     buffer = new WritableTrackingBuffer 8
     parameter = { value: testSet[0] }
     expectedNoOfDays = testSet[1]
@@ -35,10 +36,10 @@ exports.smallDateTimeDaylightSaving = (test) ->
 
 exports.dateTimeDaylightSaving = (test) ->
   type = TYPES.typeByName['DateTime']
-  for testSet in [[new Date('2015-06-18T23:59:59+0200'),42171],
-                  [new Date('2015-06-19T00:00:00+0200'),42172],
-                  [new Date('2015-06-19T23:59:59+0200'),42172],
-                  [new Date('2015-06-20T00:00:00+0200'),42173]]
+  for testSet in [[new Date('2015-06-18T21:59:59'),42171],
+                  [new Date('2015-06-18T22:00:00'),42172],
+                  [new Date('2015-06-19T21:59:59'),42172],
+                  [new Date('2015-06-19T22:00:00'),42173]]
     buffer = new WritableTrackingBuffer 16
     parameter = { value: testSet[0] }
     expectedNoOfDays = testSet[1]
@@ -46,28 +47,33 @@ exports.dateTimeDaylightSaving = (test) ->
     test.strictEqual(buffer.buffer.readInt32LE(1), expectedNoOfDays)
   test.done()
 
-exports.dateTimeDaylightSaving = (test) ->
+exports.dateTime2DaylightSaving = (test) ->
   type = TYPES.typeByName['DateTime2']
-  for testSet in [[new Date('2015-06-18T23:59:59+0200'),735766],
-                  [new Date('2015-06-19T00:00:00+0200'),735767],
-                  [new Date('2015-06-19T23:59:59+0200'),735767],
-                  [new Date('2015-06-20T00:00:00+0200'),735768]]
+  for testSet in [[new Date('2015-06-18T21:59:59'),735766],
+                  [new Date('2015-06-18T22:00:00'),735767],
+                  [new Date('2015-06-19T21:59:59'),735767],
+                  [new Date('2015-06-19T22:00:00'),735768]]
     buffer = new WritableTrackingBuffer 16
     parameter = { value: testSet[0], scale: 0 }
     expectedNoOfDays = testSet[1]
     type.writeParameterData(buffer, parameter, { useUTC: false })
-    test.strictEqual(buffer.buffer.readUIntLE(4,3), expectedNoOfDays)
+    rBuffer = new ReadableTrackingBuffer(buffer.buffer)
+    rBuffer.readUInt8()
+    rBuffer.readUInt24LE()
+    test.strictEqual(rBuffer.readUInt24LE(), expectedNoOfDays)
   test.done()
 
 exports.dateDaylightSaving = (test) ->
   type = TYPES.typeByName['Date']
-  for testSet in [[new Date('2015-06-18T23:59:59+0200'),735766],
-                  [new Date('2015-06-19T00:00:00+0200'),735767],
-                  [new Date('2015-06-19T23:59:59+0200'),735767],
-                  [new Date('2015-06-20T00:00:00+0200'),735768]]
+  for testSet in [[new Date('2015-06-18T21:59:59'),735766],
+                  [new Date('2015-06-18T22:00:00'),735767],
+                  [new Date('2015-06-19T21:59:59'),735767],
+                  [new Date('2015-06-19T22:00:00'),735768]]
     buffer = new WritableTrackingBuffer 16
     parameter = { value: testSet[0] }
     expectedNoOfDays = testSet[1]
     type.writeParameterData(buffer, parameter, { useUTC: false })
-    test.strictEqual(buffer.buffer.readUIntLE(1,3), expectedNoOfDays)
+    rBuffer = new ReadableTrackingBuffer(buffer.buffer)
+    rBuffer.readUInt8()
+    test.strictEqual(rBuffer.readUInt24LE(), expectedNoOfDays)
   test.done()

--- a/test/unit/data-type.coffee
+++ b/test/unit/data-type.coffee
@@ -23,10 +23,10 @@ exports.knownAliases = (test) ->
 # Test date calculation for non utc date during daylight savings period
 exports.smallDateTimeDaylightSaving = (test) ->
   type = TYPES.typeByName['SmallDateTime']
-  for testSet in [[new Date('2015-06-18T21:59:59'),42171],
-                  [new Date('2015-06-18T22:00:00'),42172],
-                  [new Date('2015-06-19T21:59:59'),42172],
-                  [new Date('2015-06-19T22:00:00'),42173]]
+  for testSet in [[new Date(2015,5,18,23,59,59),42171],
+                  [new Date(2015,5,19,0,0,0),42172],
+                  [new Date(2015,5,19,23,59,59),42172],
+                  [new Date(2015,5,20,0,0,0),42173]]
     buffer = new WritableTrackingBuffer 8
     parameter = { value: testSet[0] }
     expectedNoOfDays = testSet[1]
@@ -36,10 +36,10 @@ exports.smallDateTimeDaylightSaving = (test) ->
 
 exports.dateTimeDaylightSaving = (test) ->
   type = TYPES.typeByName['DateTime']
-  for testSet in [[new Date('2015-06-18T21:59:59'),42171],
-                  [new Date('2015-06-18T22:00:00'),42172],
-                  [new Date('2015-06-19T21:59:59'),42172],
-                  [new Date('2015-06-19T22:00:00'),42173]]
+  for testSet in [[new Date(2015,5,18,23,59,59),42171],
+                  [new Date(2015,5,19,0,0,0),42172],
+                  [new Date(2015,5,19,23,59,59),42172],
+                  [new Date(2015,5,20,0,0,0),42173]]
     buffer = new WritableTrackingBuffer 16
     parameter = { value: testSet[0] }
     expectedNoOfDays = testSet[1]
@@ -49,10 +49,10 @@ exports.dateTimeDaylightSaving = (test) ->
 
 exports.dateTime2DaylightSaving = (test) ->
   type = TYPES.typeByName['DateTime2']
-  for testSet in [[new Date('2015-06-18T21:59:59'),735766],
-                  [new Date('2015-06-18T22:00:00'),735767],
-                  [new Date('2015-06-19T21:59:59'),735767],
-                  [new Date('2015-06-19T22:00:00'),735768]]
+  for testSet in [[new Date(2015,5,18,23,59,59),735766],
+                  [new Date(2015,5,19,0,0,0),735767],
+                  [new Date(2015,5,19,23,59,59),735767],
+                  [new Date(2015,5,20,0,0,0),735768]]
     buffer = new WritableTrackingBuffer 16
     parameter = { value: testSet[0], scale: 0 }
     expectedNoOfDays = testSet[1]
@@ -65,10 +65,10 @@ exports.dateTime2DaylightSaving = (test) ->
 
 exports.dateDaylightSaving = (test) ->
   type = TYPES.typeByName['Date']
-  for testSet in [[new Date('2015-06-18T21:59:59'),735766],
-                  [new Date('2015-06-18T22:00:00'),735767],
-                  [new Date('2015-06-19T21:59:59'),735767],
-                  [new Date('2015-06-19T22:00:00'),735768]]
+  for testSet in [[new Date(2015,5,18,23,59,59),735766],
+                  [new Date(2015,5,19,0,0,0),735767],
+                  [new Date(2015,5,19,23,59,59),735767],
+                  [new Date(2015,5,20,0,0,0),735768]]
     buffer = new WritableTrackingBuffer 16
     parameter = { value: testSet[0] }
     expectedNoOfDays = testSet[1]

--- a/test/unit/data-type.coffee
+++ b/test/unit/data-type.coffee
@@ -1,4 +1,5 @@
 TYPES = require('../../src/data-type')
+WritableTrackingBuffer = require('../../src/tracking-buffer/writable-tracking-buffer')
 
 exports.noTypeOverridesByAliases = (test) ->
   typesByName = {}
@@ -16,4 +17,57 @@ exports.knownAliases = (test) ->
   for alias in ['UniqueIdentifier', 'Date', 'Time', 'DateTime2', 'DateTimeOffset']
     test.strictEqual(TYPES.typeByName[alias], TYPES.typeByName["#{alias}N"], "Alias #{alias} is not pointing to #{alias}N type.")
 
+  test.done()
+
+# Test date calculation for non utc date during daylight savings period
+exports.smallDateTimeDaylightSaving = (test) ->
+  type = TYPES.typeByName['SmallDateTime']
+  for testSet in [[new Date('2015-06-18T23:59:59+0200'),42171],
+                  [new Date('2015-06-19T00:00:00+0200'),42172],
+                  [new Date('2015-06-19T23:59:59+0200'),42172],
+                  [new Date('2015-06-20T00:00:00+0200'),42173]]
+    buffer = new WritableTrackingBuffer 8
+    parameter = { value: testSet[0] }
+    expectedNoOfDays = testSet[1]
+    type.writeParameterData(buffer, parameter, { useUTC: false })
+    test.strictEqual(buffer.buffer.readUInt16LE(1), expectedNoOfDays)
+  test.done()
+
+exports.dateTimeDaylightSaving = (test) ->
+  type = TYPES.typeByName['DateTime']
+  for testSet in [[new Date('2015-06-18T23:59:59+0200'),42171],
+                  [new Date('2015-06-19T00:00:00+0200'),42172],
+                  [new Date('2015-06-19T23:59:59+0200'),42172],
+                  [new Date('2015-06-20T00:00:00+0200'),42173]]
+    buffer = new WritableTrackingBuffer 16
+    parameter = { value: testSet[0] }
+    expectedNoOfDays = testSet[1]
+    type.writeParameterData(buffer, parameter, { useUTC: false })
+    test.strictEqual(buffer.buffer.readInt32LE(1), expectedNoOfDays)
+  test.done()
+
+exports.dateTimeDaylightSaving = (test) ->
+  type = TYPES.typeByName['DateTime2']
+  for testSet in [[new Date('2015-06-18T23:59:59+0200'),735766],
+                  [new Date('2015-06-19T00:00:00+0200'),735767],
+                  [new Date('2015-06-19T23:59:59+0200'),735767],
+                  [new Date('2015-06-20T00:00:00+0200'),735768]]
+    buffer = new WritableTrackingBuffer 16
+    parameter = { value: testSet[0], scale: 0 }
+    expectedNoOfDays = testSet[1]
+    type.writeParameterData(buffer, parameter, { useUTC: false })
+    test.strictEqual(buffer.buffer.readUIntLE(4,3), expectedNoOfDays)
+  test.done()
+
+exports.dateDaylightSaving = (test) ->
+  type = TYPES.typeByName['Date']
+  for testSet in [[new Date('2015-06-18T23:59:59+0200'),735766],
+                  [new Date('2015-06-19T00:00:00+0200'),735767],
+                  [new Date('2015-06-19T23:59:59+0200'),735767],
+                  [new Date('2015-06-20T00:00:00+0200'),735768]]
+    buffer = new WritableTrackingBuffer 16
+    parameter = { value: testSet[0] }
+    expectedNoOfDays = testSet[1]
+    type.writeParameterData(buffer, parameter, { useUTC: false })
+    test.strictEqual(buffer.buffer.readUIntLE(1,3), expectedNoOfDays)
   test.done()


### PR DESCRIPTION
In some cases the date written and read from database are not the same. This only happens if the connection is established with options.useUTC = false. My node and sql server run both in the CET/CEST timezone.

Example: 
Input date "2015-06-18T22:00:00Z" -> 2015-06-19 00:00:00 CEST
Output date "2015-06-17T22:00:00Z" -> 2015-06-18 00:00:00 CEST

This was caused because the EPOCH_DATE used to calculate the days since 1900-01-01 did not consider the daylight savings difference. The calculated difference was 42171.958333333336, which was floored down to 42171. When taking the DST into account the difference would be 42172 days.

fixed datatypes:
datetime
datetime2
smalldatetime
date

