### PR TITLE
Publish npm modules through travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,12 @@ node_js:
   - "1.8"
   - "2.0"
   - "2.3"
+
+deploy:
+  provider: npm
+  email: "schreiber.arthur@googlemail.com"
+  api_key:
+    secure: bsf8+yRHbphPCaP6w0Fqg66zOEyBss/XGpKqSiESrBI4cbIPAKKvUL/SFzibKqRV6mtYYJGmwRSaS4okhwSeCvi0hnHqAMBQQs863eatoUNbTTrGfH5EB97jaqkcdpCCvtup2Uqu+GcHXRgW1HsQ51jAntfY5DAazVsuRCTNNHI=
+  on:
+    tags: true
+    node: "0.10"


### PR DESCRIPTION
This extends the travis config to automatically publish a new `tedious` package after a git tag was pushed and the travis build for the tag passed.

---

This probably needs some discussion. //cc @bretcope @pekim @patriksimek 

The idea here is to use automation wherever possible, and to align the workflow between all collaborators. E.g. the 1.10.0 release was a bit messy, we (still) don't have a git tag for it, and the tests actually failed on travis, because the package.json contained the `^` symbol which does not work on Node < `0.10`.