### PR TITLE
Fix for issue #262 changes port number

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -82,7 +82,7 @@ class Connection extends EventEmitter
         connectTimeout: ->
           @transitionTo(@STATE.FINAL)
         reconnect: ->
-          @config.server = @routingData.server
+          @config.options.redirectionServer = @routingData.server
           @config.options.port = @routingData.port
           @transitionTo(@STATE.CONNECTING)
 
@@ -471,7 +471,7 @@ class Connection extends EventEmitter
       @connectOnPort(@config.options.port)
     else
       instanceLookup(
-        @config.server
+        @config.options.redirectionServer or @config.server
         @config.options.instanceName
         (message, port) =>
           if @state == @STATE.FINAL
@@ -486,7 +486,7 @@ class Connection extends EventEmitter
     @socket = new Socket({})
 
     connectOpts =
-      host: @config.server
+      host: @config.options.redirectionServer or @config.server
       port: port
 
     if @config.options.localAddress
@@ -517,7 +517,7 @@ class Connection extends EventEmitter
       @requestTimer = setTimeout(@requestTimeout, @config.options.requestTimeout)
 
   connectTimeout: =>
-    message = "Failed to connect to #{@config.server}:#{@config.options.port} in #{@config.options.connectTimeout}ms"
+    message = "Failed to connect to #{@config.options.redirectionServer or @config.server}:#{@config.options.port} in #{@config.options.connectTimeout}ms"
 
     @debug.log(message)
     @emit('connect', ConnectionError(message, 'ETIMEOUT'))
@@ -561,7 +561,7 @@ class Connection extends EventEmitter
 
   socketError: (error) =>
     if @state == @STATE.CONNECTING
-      message = "Failed to connect to #{@config.server}:#{@config.options.port} - #{error.message}"
+      message = "Failed to connect to #{@config.options.redirectionServer or @config.server}:#{@config.options.port} - #{error.message}"
       @debug.log(message)
       @emit('connect', ConnectionError(message, 'ESOCKET'))
     else
@@ -573,7 +573,7 @@ class Connection extends EventEmitter
   socketConnect: =>
     @socket.setKeepAlive(true, KEEP_ALIVE_INITIAL_DELAY)
     @closed = false
-    @debug.log("connected to #{@config.server}:#{@config.options.port}")
+    @debug.log("connected to #{@config.options.redirectionServer or @config.server}:#{@config.options.port}")
     @dispatchEvent('socketConnect')
 
   socketEnd: =>
@@ -581,7 +581,7 @@ class Connection extends EventEmitter
     @transitionTo(@STATE.FINAL)
 
   socketClose: =>
-    @debug.log("connection to #{@config.server}:#{@config.options.port} closed")
+    @debug.log("connection to #{@config.options.redirectionServer or @config.server}:#{@config.options.port} closed")
     if @state is @STATE.REROUTING
       @debug.log("Rerouting to #{@routingData.server}:#{@routingData.port}")
       @dispatchEvent('reconnect')
@@ -618,7 +618,7 @@ class Connection extends EventEmitter
       userName: @config.userName
       password: @config.password
       database: @config.options.database
-      serverName: @config.server
+      serverName: @config.options.redirectionServer or @config.server
       appName: @config.options.appName
       packetSize: @config.options.packetSize
       tdsVersion: @config.options.tdsVersion


### PR DESCRIPTION
Actual issue was when a connection is redirected to a different server
name as well as port number, only the change to the port number was
being saved.  Pushing the redirection servername into the options
object fixes the problem.