### PR TITLE
Do not pass additional arguments to transaction continuation.

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -831,7 +831,7 @@ set xact_abort #{xact_abort}"""
 
     txDone = (err, done) =>
       args = []
-      args.push(arguments[i]) for i in [2..arguments.length]
+      args.push(arguments[i]) for i in [2...arguments.length]
 
       if err
         if @inTransaction


### PR DESCRIPTION
This fixes a tiny issue where the continuation that was passed to the `transaction` method
would be called with one more argument than expected. This argument was always `undefined`,
and this bug was only affecting the `arguments.length` value.