### PR TITLE
data-type validation should validate 'Invalid Date'

### DIFF
--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -125,11 +125,9 @@ TYPE =
         buffer.writeUInt8(0)
     validate: (value) ->
       if not value? then return null
-      if `value == "Invalid Date"` then return new TypeError "Invalid date."
-      if value instanceof Date then return value
-      value = Date.parse value
+      if not (value instanceof Date) then value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
-      value
+      return value
   0x3B:
     type: 'FLT4'
     name: 'Real'
@@ -208,11 +206,9 @@ TYPE =
         buffer.writeUInt8(0)
     validate: (value) ->
       if not value? then return null
-      if `value == "Invalid Date"` then return new TypeError "Invalid date."
-      if value instanceof Date then return value
-      value = Date.parse value
+      if not (value instanceof Date) then value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
-      value
+      return value
   0x3E:
     type: 'FLT8'
     name: 'Float'
@@ -913,11 +909,9 @@ TYPE =
         buffer.writeUInt8 0
     validate: (value) ->
       if not value? then return null
-      if `value == "Invalid Date"` then return new TypeError "Invalid date."
-      if value instanceof Date then return value
-      value = Date.parse value
+      if not (value instanceof Date) then value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
-      value
+      return value
   0x2A:
     type: 'DATETIME2N'
     name: 'DateTime2N'
@@ -976,11 +970,9 @@ TYPE =
         buffer.writeUInt8 0
     validate: (value) ->
       if not value? then return null
-      if `value == "Invalid Date"` then return new TypeError "Invalid date."
-      if value instanceof Date then return value
-      value = Date.parse value
+      if not (value instanceof Date) then value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
-      value
+      return value
   0x2B:
     type: 'DATETIMEOFFSETN'
     name: 'DateTimeOffsetN'
@@ -1036,11 +1028,9 @@ TYPE =
         buffer.writeUInt8 0
     validate: (value) ->
       if not value? then return null
-      if `value == "Invalid Date"` then return new TypeError "Invalid date."
-      if value instanceof Date then return value
-      value = Date.parse value
+      if not (value instanceof Date) then value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
-      value
+      return value
   0xF0:
     type: 'UDTTYPE'
     name: 'UDT'

--- a/src/data-type.coffee
+++ b/src/data-type.coffee
@@ -125,6 +125,7 @@ TYPE =
         buffer.writeUInt8(0)
     validate: (value) ->
       if not value? then return null
+      if `value == "Invalid Date"` then return new TypeError "Invalid date."
       if value instanceof Date then return value
       value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
@@ -207,6 +208,7 @@ TYPE =
         buffer.writeUInt8(0)
     validate: (value) ->
       if not value? then return null
+      if `value == "Invalid Date"` then return new TypeError "Invalid date."
       if value instanceof Date then return value
       value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
@@ -911,6 +913,7 @@ TYPE =
         buffer.writeUInt8 0
     validate: (value) ->
       if not value? then return null
+      if `value == "Invalid Date"` then return new TypeError "Invalid date."
       if value instanceof Date then return value
       value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
@@ -973,6 +976,7 @@ TYPE =
         buffer.writeUInt8 0
     validate: (value) ->
       if not value? then return null
+      if `value == "Invalid Date"` then return new TypeError "Invalid date."
       if value instanceof Date then return value
       value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."
@@ -1032,6 +1036,7 @@ TYPE =
         buffer.writeUInt8 0
     validate: (value) ->
       if not value? then return null
+      if `value == "Invalid Date"` then return new TypeError "Invalid date."
       if value instanceof Date then return value
       value = Date.parse value
       if isNaN value then return new TypeError "Invalid date."


### PR DESCRIPTION
The current data-type.js validation for datetime, does not account for 'Invalid Date' validation. As a result, the driver throws an uncaught exception.

Example: new Date('16:24') will pass the validation function but when reaches writable-tracking-buffer.js, just blows up. Such request, if within a transaction, leaves the transaction unresolved till the app exits.