### PR TITLE
Stream Parser using Generators

### DIFF
--- a/benchmarks/benchmarks.coffee
+++ b/benchmarks/benchmarks.coffee
@@ -1,0 +1,122 @@
+{Request, TYPES} = require "../src/tedious"
+
+module.exports =
+
+  "nvarchar (small)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.NVarChar, "asdf")
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+  "nvarchar (large)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] nvarchar(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.NVarChar, new Array(5 * 1024 * 1024).join("x"))
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+  "varbinary (small)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.VarBinary, new Buffer("asdf"))
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+  "varbinary (4)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(4))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        request.addParameter("value", TYPES.VarBinary, new Buffer("asdf"))
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+
+  "varbinary (large)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        buf = new Buffer(5 * 1024 * 1024)
+        buf.fill("x")
+        request.addParameter("value", TYPES.VarBinary, buf)
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)
+
+  "varbinary (huge)":
+    setup: (connection, cb) ->
+      request = new Request "CREATE TABLE #benchmark ([value] varbinary(max))", (err) ->
+        return cb(err) if err
+
+        request = new Request "INSERT INTO #benchmark ([value]) VALUES (@value)", cb
+        buf = new Buffer(50 * 1024 * 1024)
+        buf.fill("x")
+        request.addParameter("value", TYPES.VarBinary, buf)
+        connection.execSql(request)
+
+      connection.execSqlBatch(request)
+
+    exec: (connection, cb) ->
+      request = new Request "SELECT * FROM #benchmark", cb
+      connection.execSql(request)
+
+    teardown: (connection, cb) ->
+      request = new Request "DROP TABLE #benchmark", cb
+      connection.execSqlBatch(request)

--- a/benchmarks/query.coffee
+++ b/benchmarks/query.coffee
@@ -1,0 +1,57 @@
+fs = require "fs"
+
+Benchmark = require("benchmark")
+{Connection} = require "../src/tedious"
+
+setup = (cb) ->
+  config = JSON.parse(fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')).config
+
+  connection = new Connection(config)
+  connection.on "connect", ->
+    cb(connection)
+
+benchmarks = require("./benchmarks")
+
+setup (connection) ->
+  execute = (names, cb) ->
+    return cb() unless names.length
+
+    name = names.shift()
+
+    memMax = memStart = process.memoryUsage().rss;
+
+    benchmark = benchmarks[name]
+    benchmark.setup connection, (err) ->
+      if (err)
+        console.log("Error in '#{name}' setup:")
+        console.error(err)
+
+      bench = new Benchmark name,
+        defer: true
+        fn: (deferred) ->
+          benchmark.exec connection, (err) ->
+            if (err)
+              console.log("Error in '#{name}' execution:")
+              console.error(err)
+
+            memMax = Math.max(memMax, process.memoryUsage().rss);
+
+            deferred.resolve()
+
+      bench.on "complete", (event) ->
+        console.log(String(event.target))
+        console.log("Memory:", (memMax - memStart)/1024/1024)
+
+        benchmark.teardown connection, (err) ->
+          if (err)
+            console.log("Error in '#{name}' teardown:")
+            console.error(err)
+
+          execute(names, cb)
+
+      console.log "Benchmarking '#{name}'"
+      bench.run "async": true
+
+  execute Object.keys(benchmarks), ->
+    connection.close()
+    console.log("Done!")

--- a/package.json
+++ b/package.json
@@ -37,19 +37,31 @@
     "node": ">= 0.10"
   },
   "dependencies": {
+    "babel-runtime": "^5.8.12",
     "big-number": "0.3.1",
+    "bl": "^1.0.0",
     "iconv-lite": "0.4.7",
+    "readable-stream": "^2.0.2",
     "sprintf": "0.1.5"
   },
   "devDependencies": {
     "async": "0.9.0",
+    "babel": "^5.8.12",
+    "benchmark": "^1.0.0",
     "coffee-script": "1.9.0",
     "nodeunit": "0.9.0"
   },
   "scripts": {
-    "test": "node_modules/.bin/nodeunit --reporter minimal test/register-coffee.js test/unit/ test/unit/token/ test/unit/tracking-buffer",
-    "test-all": "node_modules/.bin/nodeunit --reporter minimal test/register-coffee.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",
-    "test-integration": "node_modules/.bin/nodeunit --reporter minimal test/register-coffee.js test/integration/",
-    "prepublish": "node_modules/.bin/coffee scripts/build.coffee"
+    "test": "nodeunit --reporter minimal test/register-coffee.js test/unit/ test/unit/token/ test/unit/tracking-buffer",
+    "test-all": "nodeunit --reporter minimal test/register-coffee.js test/unit/ test/unit/token/ test/unit/tracking-buffer test/integration/",
+    "test-integration": "nodeunit --reporter minimal test/register-coffee.js test/integration/",
+    "prepublish": "coffee scripts/build.coffee"
+  },
+  "babel": {
+    "whitelist": [
+      "regenerator",
+      "es6.modules",
+      "runtime"
+    ]
   }
 }

--- a/scripts/build.coffee
+++ b/scripts/build.coffee
@@ -29,7 +29,14 @@ isdir = (dir) ->
 
 if isdir 'src'
   rmdir 'lib' if isdir 'lib'
+
   coffee_bin = path.join 'node_modules', '.bin', 'coffee'
+  babel_bin = path.join 'node_modules', '.bin', 'babel'
+
   child.exec "#{coffee_bin} -b -c -o lib/ src/", (err) ->
     if err
       console.error err
+    else
+      child.exec "#{babel_bin} lib --out-dir lib", (err) ->
+        if err
+          console.error err

--- a/src/collation.coffee
+++ b/src/collation.coffee
@@ -2,7 +2,6 @@
 
 exports.codepageByLcid =
   0x436: 'CP1252'
-  0x41C: 'CP1250'
   0x401: 'CP1256'
   0x801: 'CP1256'
   0xC01: 'CP1256'
@@ -69,7 +68,6 @@ exports.codepageByLcid =
   0x810: 'CP1252'
   0x411: 'CP932'
   0x10411: 'CP932'
-  0x412: 'CP949'
   0x412: 'CP949'
   0x426: 'CP1257'
   0x427: 'CP1257'

--- a/src/login7-payload.coffee
+++ b/src/login7-payload.coffee
@@ -227,8 +227,7 @@ class Login7Payload
       @addVariableDataString(variableData, @changePassword)           # Introduced in TDS 7.2
       variableData.offsetsAndLengths.writeUInt32LE(@sspiLong)         # Introduced in TDS 7.2
 
-    variableData.offsetsAndLengths.data =
-      Buffer.concat([variableData.offsetsAndLengths.data, variableData.data.data])
+    Buffer.concat([variableData.offsetsAndLengths.data, variableData.data.data])
 
   addVariableDataBuffer: (variableData, buffer) ->
     variableData.offsetsAndLengths.writeUInt16LE(variableData.offset)

--- a/src/stream-parser.coffee
+++ b/src/stream-parser.coffee
@@ -1,0 +1,127 @@
+stream = require('readable-stream')
+BufferList = require('bl')
+
+class Job
+  constructor: (@length, @execute) ->
+
+# These jobs are non-dynamic, so we can reuse the job objects.
+# This should reduce GC pressure a bit (as less objects will be
+# created and garbage collected during stream parsing).
+JOBS =
+  'readInt8': new Job 1, (buffer, offset) ->
+    buffer.readInt8 offset
+
+  'readUInt8': new Job 1, (buffer, offset) ->
+    buffer.readUInt8 offset
+
+  'readInt16LE': new Job 2, (buffer, offset) ->
+    buffer.readInt16LE offset
+
+  'readInt16BE': new Job 2, (buffer, offset) ->
+    buffer.readInt16BE offset
+
+  'readUInt16LE': new Job 2, (buffer, offset) ->
+    buffer.readUInt16LE offset
+
+  'readUInt16BE': new Job 2, (buffer, offset) ->
+    buffer.readUInt16BE offset
+
+  'readInt32LE': new Job 4, (buffer, offset) ->
+    buffer.readInt32LE offset
+
+  'readInt32BE': new Job 4, (buffer, offset) ->
+    buffer.readInt32BE offset
+
+  'readUInt32LE': new Job 4, (buffer, offset) ->
+    buffer.readUInt32LE offset
+
+  'readUInt32BE': new Job 4, (buffer, offset) ->
+    buffer.readUInt32BE offset
+
+  'readInt64LE': new Job 8, (buffer, offset) ->
+    2 ** 32 * buffer.readInt32LE(offset + 4) + (if buffer[offset + 4] & 0x80 == 0x80 then 1 else -1) * buffer.readUInt32LE(offset)
+
+  'readInt64BE': new Job 8, (buffer, offset) ->
+    2 ** 32 * buffer.readInt32BE(offset) + (if buffer[offset] & 0x80 == 0x80 then 1 else -1) * buffer.readUInt32BE(offset + 4)
+
+  'readUInt64LE': new Job 8, (buffer, offset) ->
+    2 ** 32 * buffer.readUInt32LE(offset + 4) + buffer.readUInt32LE(offset)
+
+  'readUInt64BE': new Job 8, (buffer, offset) ->
+    2 ** 32 * buffer.readUInt32BE(offset) + buffer.readUInt32BE(offset + 4)
+
+  'readFloatLE': new Job 4, (buffer, offset) ->
+    buffer.readFloatLE offset
+
+  'readFloatBE': new Job 4, (buffer, offset) ->
+    buffer.readFloatBE offset
+
+  'readDoubleLE': new Job 8, (buffer, offset) ->
+    buffer.readDoubleLE offset
+
+  'readDoubleBE': new Job 8, (buffer, offset) ->
+    buffer.readDoubleBE offset
+
+class StreamParser extends stream.Transform
+  constructor: (options) ->
+    options = options or {}
+    options.objectMode = true if !options.objectMode?
+
+    super(options)
+
+    @buffer = new BufferList
+    @generator = undefined
+    @currentStep = undefined
+
+  parser: ->
+    throw new Error('Not implemented')
+
+  _transform: (input, encoding, done) ->
+    offset = 0
+    @buffer.append input
+
+    if !@generator
+      @generator = @parser()
+      @currentStep = @generator.next()
+
+    job = undefined
+    result = undefined
+    length = undefined
+
+    while !@currentStep.done
+      job = @currentStep.value
+
+      if !(job instanceof Job)
+        return done(new Error('invalid job type'))
+
+      length = job.length
+      if @buffer.length - offset < length
+        break
+
+      result = job.execute(@buffer, offset)
+      offset += length
+      @currentStep = @generator.next(result)
+
+    @buffer.consume offset
+
+    if @currentStep.done
+      @push null
+
+    done()
+
+  Object.keys(JOBS).forEach (jobName) =>
+    @::[jobName] = -> JOBS[jobName]
+
+  readBuffer: (length) ->
+    new Job length, (buffer, offset) ->
+      buffer.slice offset, offset + length
+
+  readString: (length) ->
+    new Job length, (buffer, offset) ->
+      buffer.toString 'utf8', offset, offset + length
+
+  skip: (length) ->
+    new Job length, (buffer, offset) ->
+      # Noop
+
+module.exports = StreamParser

--- a/src/token/infoerror-token-parser.coffee
+++ b/src/token/infoerror-token-parser.coffee
@@ -1,36 +1,37 @@
 # s2.2.7.9, s2.2.7.10
 
-parser = (buffer, options) ->
-  length = buffer.readUInt16LE()
-  number = buffer.readUInt32LE()
-  state = buffer.readUInt8()
-  class_ = buffer.readUInt8()
-  message = buffer.readUsVarchar()
-  serverName = buffer.readBVarchar()
-  procName = buffer.readBVarchar()
+parseToken = (parser, options) ->
+  length = yield parser.readUInt16LE()
+  number = yield parser.readUInt32LE()
+  state = yield parser.readUInt8()
+  clazz = yield parser.readUInt8()
+  message = yield from parser.readUsVarChar()
+  serverName = yield from parser.readBVarChar()
+  procName = yield from parser.readBVarChar()
+
   if options.tdsVersion < '7_2'
-    lineNumber = buffer.readUInt16LE()
+    lineNumber = yield parser.readUInt16LE()
   else
-    lineNumber = buffer.readUInt32LE()
+    lineNumber = yield parser.readUInt32LE()
 
   token =
     number: number
     state: state
-    class: class_
+    class: clazz
     message: message
     serverName: serverName
     procName: procName
     lineNumber: lineNumber
 
-infoParser = (buffer, colMetadata, options) ->
-  token = parser(buffer, options)
+infoParser = (parser, colMetadata, options) ->
+  token = yield from parseToken(parser, options)
   token.name = 'INFO'
   token.event = 'infoMessage'
 
   token
 
-errorParser = (buffer, colMetadata, options) ->
-  token = parser(buffer, options)
+errorParser = (parser, colMetadata, options) ->
+  token = yield from parseToken(parser, options)
   token.name = 'ERROR'
   token.event = 'errorMessage'
 

--- a/src/token/loginack-token-parser.coffee
+++ b/src/token/loginack-token-parser.coffee
@@ -6,20 +6,20 @@ interfaceTypes =
   0: 'SQL_DFLT'
   1: 'SQL_TSQL'
 
-parser = (buffer) ->
-  length = buffer.readUInt16LE()
+module.exports = (parser) ->
+  length = yield parser.readUInt16LE()
 
-  interfaceNumber = buffer.readUInt8()
+  interfaceNumber = yield parser.readUInt8()
   interfaceType = interfaceTypes[interfaceNumber]
-  tdsVersionNumber = buffer.readUInt32BE()
+  tdsVersionNumber = yield parser.readUInt32BE()
   tdsVersion = versions[tdsVersionNumber]
-  progName = buffer.readBVarchar()
+  progName = yield from parser.readBVarChar()
 
   progVersion =
-    major: buffer.readUInt8()
-    minor: buffer.readUInt8()
-    buildNumHi: buffer.readUInt8()
-    buildNumLow: buffer.readUInt8()
+    major: yield parser.readUInt8()
+    minor: yield parser.readUInt8()
+    buildNumHi: yield parser.readUInt8()
+    buildNumLow: yield parser.readUInt8()
 
   # Return token
   name: 'LOGINACK'
@@ -28,5 +28,3 @@ parser = (buffer) ->
   tdsVersion: tdsVersion
   progName: progName
   progVersion: progVersion
-
-module.exports = parser

--- a/src/token/nbcrow-token-parser.coffee
+++ b/src/token/nbcrow-token-parser.coffee
@@ -3,9 +3,9 @@
 valueParse = require('../value-parser')
 sprintf = require('sprintf').sprintf
 
-parser = (buffer, columnsMetaData, options) ->
+module.exports = (parser, columnsMetaData, options) ->
   length = Math.ceil columnsMetaData.length / 8
-  bytes = buffer.readBuffer length
+  bytes = yield parser.readBuffer(length)
   bitmap = []
 
   for byte in bytes
@@ -19,7 +19,7 @@ parser = (buffer, columnsMetaData, options) ->
     if bitmap[index]
       value = null
     else
-      value = valueParse(buffer, columnMetaData, options)
+      value = yield from valueParse(parser, columnMetaData)
 
     column =
       value: value
@@ -35,5 +35,3 @@ parser = (buffer, columnsMetaData, options) ->
   name: 'NBCROW'
   event: 'row'
   columns: columns
-
-module.exports = parser

--- a/src/token/order-token-parser.coffee
+++ b/src/token/order-token-parser.coffee
@@ -1,15 +1,13 @@
 # s2.2.7.14
 
-parser = (buffer) ->
-  columnCount = buffer.readUInt16LE() / 2;
+module.exports = (parser) ->
+  columnCount = (yield parser.readUInt16LE("length")) / 2
 
   orderColumns = []
   for c in [1..columnCount]
-    orderColumns.push(buffer.readUInt16LE())
+    orderColumns.push(yield parser.readUInt16LE())
 
   # Return token
   name: 'ORDER'
   event: 'order'
   orderColumns: orderColumns
-
-module.exports = parser

--- a/src/token/returnstatus-token-parser.coffee
+++ b/src/token/returnstatus-token-parser.coffee
@@ -1,11 +1,9 @@
 # s2.2.7.16
 
-parser = (buffer) ->
-  value = buffer.readInt32LE()
+module.exports = (parser) ->
+  value = yield parser.readInt32LE()
 
   token =
     name: 'RETURNSTATUS'
     event: 'returnStatus'
     value: value
-
-module.exports = parser

--- a/src/token/returnvalue-token-parser.coffee
+++ b/src/token/returnvalue-token-parser.coffee
@@ -3,12 +3,12 @@
 metadataParse = require('../metadata-parser')
 valueParse = require('../value-parser')
 
-parser = (buffer, colMetadata, options) ->
-  paramOrdinal = buffer.readUInt16LE()
-  paramName = buffer.readBVarchar()
-  status = buffer.readUInt8()
-  metadata = metadataParse(buffer, options)
-  value = valueParse(buffer, metadata, options)
+module.exports = (parser, colMetadata, options) ->
+  paramOrdinal = yield parser.readUInt16LE()
+  paramName = yield from parser.readBVarChar()
+  status = yield parser.readUInt8()
+  metadata = yield from metadataParse(parser, options)
+  value = yield from valueParse(parser, metadata, options)
 
   if paramName.charAt(0) == '@'
     paramName = paramName.slice(1)
@@ -20,5 +20,3 @@ parser = (buffer, colMetadata, options) ->
     paramName: paramName
     metadata: metadata
     value: value
-
-module.exports = parser

--- a/src/token/row-token-parser.coffee
+++ b/src/token/row-token-parser.coffee
@@ -3,17 +3,17 @@
 valueParse = require('../value-parser')
 sprintf = require('sprintf').sprintf
 
-parser = (buffer, columnsMetaData, options) ->
+module.exports = (parser, columnsMetaData, options) ->
   columns = if options.useColumnNames then {} else []
   for columnMetaData in columnsMetaData
     #console.log sprintf('Token @ 0x%02X', buffer.position)
 
-    value = valueParse(buffer, columnMetaData, options)
+    value = yield from valueParse(parser, columnMetaData, options)
 
     column =
       value: value
       metadata: columnMetaData
-    
+
     if options.useColumnNames
       unless columns[columnMetaData.colName]?
         columns[columnMetaData.colName] = column
@@ -24,5 +24,3 @@ parser = (buffer, columnsMetaData, options) ->
   name: 'ROW'
   event: 'row'
   columns: columns
-
-module.exports = parser

--- a/src/token/sspi-token-parser.coffee
+++ b/src/token/sspi-token-parser.coffee
@@ -1,26 +1,24 @@
-parseChallenge = (buffer) ->
+parseChallenge = (parser) ->
   challenge = {}
-  buffer.position = 3 # the token buffer starts w/ junk, this skips it
-  challenge.magic = buffer.readString(8, 'utf8')
-  challenge.type = buffer.readInt32LE()
-  challenge.domainLen = buffer.readInt16LE()
-  challenge.domainMax = buffer.readInt16LE()
-  challenge.domainOffset = buffer.readInt32LE()
-  challenge.flags = buffer.readInt32LE()
-  challenge.nonce = buffer.readBuffer(8)
-  challenge.zeroes = buffer.readBuffer(8)
-  challenge.targetLen = buffer.readInt16LE()
-  challenge.targetMax = buffer.readInt16LE()
-  challenge.targetOffset = buffer.readInt32LE()
-  challenge.oddData = buffer.readBuffer(8)
-  challenge.domain = buffer.readString(challenge.domainLen, 'ucs2')
-  challenge.target = buffer.readBuffer(challenge.targetLen)
+  yield parser.readBuffer(3) # the token buffer starts w/ junk, this skips it
+  challenge.magic = yield parser.readString(8)
+  challenge.type = yield parser.readInt32LE()
+  challenge.domainLen = yield parser.readInt16LE()
+  challenge.domainMax = yield parser.readInt16LE()
+  challenge.domainOffset = yield parser.readInt32LE()
+  challenge.flags = yield parser.readInt32LE()
+  challenge.nonce = yield parser.readBuffer(8)
+  challenge.zeroes = yield parser.readBuffer(8)
+  challenge.targetLen = yield parser.readInt16LE()
+  challenge.targetMax = yield parser.readInt16LE()
+  challenge.targetOffset = yield parser.readInt32LE()
+  challenge.oddData = yield parser.readBuffer(8)
+  challenge.domain = (yield parser.readBuffer(challenge.domainLen)).toString('ucs2')
+  challenge.target = yield parser.readBuffer(challenge.targetLen)
   challenge
 
-parser = (buffer) ->
-  challenge = parseChallenge(buffer)
+module.exports = (parser) ->
+  challenge =  yield from parseChallenge(parser)
   name: 'SSPICHALLENGE'
   event: 'sspichallenge'
   ntlmpacket: challenge
-
-module.exports = parser

--- a/src/token/stream-parser.coffee
+++ b/src/token/stream-parser.coffee
@@ -1,0 +1,87 @@
+StreamParser = require("../stream-parser")
+
+TYPE = require('./token').TYPE
+
+tokenParsers = {}
+tokenParsers[TYPE.COLMETADATA] = require('./colmetadata-token-parser')
+tokenParsers[TYPE.DONE] = require('./done-token-parser').doneParser
+tokenParsers[TYPE.DONEINPROC] = require('./done-token-parser').doneInProcParser
+tokenParsers[TYPE.DONEPROC] = require('./done-token-parser').doneProcParser
+tokenParsers[TYPE.ENVCHANGE] = require('./env-change-token-parser')
+tokenParsers[TYPE.ERROR] = require('./infoerror-token-parser').errorParser
+tokenParsers[TYPE.INFO] = require('./infoerror-token-parser').infoParser
+tokenParsers[TYPE.LOGINACK] = require('./loginack-token-parser')
+tokenParsers[TYPE.ORDER] = require('./order-token-parser')
+tokenParsers[TYPE.RETURNSTATUS] = require('./returnstatus-token-parser')
+tokenParsers[TYPE.RETURNVALUE] = require('./returnvalue-token-parser')
+tokenParsers[TYPE.ROW] = require('./row-token-parser')
+tokenParsers[TYPE.NBCROW] = require('./nbcrow-token-parser')
+tokenParsers[TYPE.SSPI] = require('./sspi-token-parser')
+
+module.exports = class Parser extends StreamParser
+  constructor: (@debug, @colMetadata, @options) ->
+    super()
+
+  parser: ->
+    while true
+      type = yield @readUInt8()
+
+      if tokenParsers[type]
+        token = yield from tokenParsers[type](@, @colMetadata, @options)
+
+        if token
+          switch token.name
+            when 'COLMETADATA'
+              @colMetadata = token.columns
+
+          @push(token)
+      else
+        throw new Error("Token type #{type} not implemented")
+
+    undefined
+
+  # Read a Unicode String (BVARCHAR)
+  readBVarChar: (name) ->
+    length = yield @readUInt8()
+    data = yield @readBuffer(length * 2)
+    data.toString("ucs2")
+
+  # Read a Unicode String (USVARCHAR)
+  readUsVarChar: (name) ->
+    length = yield @readUInt16LE()
+    data = yield @readBuffer(length * 2)
+    data.toString("ucs2")
+
+  # Read binary data (BVARBYTE)
+  readBVarByte: (name) ->
+    length = yield @readUInt8()
+    yield @readBuffer(length)
+
+  readUInt24LE: (name) ->
+    low = yield @readUInt16LE()
+    high = yield @readUInt8()
+    low | (high << 16)
+
+  readUInt40LE: (name) ->
+    low = yield @readUInt32LE()
+    high = yield @readUInt8()
+    (0x100000000 * high) + low
+
+  readUNumeric64LE: (name) ->
+    low = yield @readUInt32LE()
+    high = yield @readUInt32LE()
+    (0x100000000 * high) + low
+
+  readUNumeric96LE: (name) ->
+    dword1 = yield @readUInt32LE()
+    dword2 = yield @readUInt32LE()
+    dword3 = yield @readUInt32LE()
+    dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3)
+
+  readUNumeric128LE: (name) ->
+    dword1 = yield @readUInt32LE()
+    dword2 = yield @readUInt32LE()
+    dword3 = yield @readUInt32LE()
+    dword4 = yield @readUInt32LE()
+
+    dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3) + (0x100000000 * 0x100000000 * 0x100000000 * dword4)

--- a/src/token/token-stream-parser.coffee
+++ b/src/token/token-stream-parser.coffee
@@ -1,22 +1,5 @@
-ReadableTrackingBuffer = require('../tracking-buffer/tracking-buffer').ReadableTrackingBuffer
 EventEmitter = require('events').EventEmitter
-TYPE = require('./token').TYPE
-
-tokenParsers = {}
-tokenParsers[TYPE.COLMETADATA] = require('./colmetadata-token-parser')
-tokenParsers[TYPE.DONE] = require('./done-token-parser').doneParser
-tokenParsers[TYPE.DONEINPROC] = require('./done-token-parser').doneInProcParser
-tokenParsers[TYPE.DONEPROC] = require('./done-token-parser').doneProcParser
-tokenParsers[TYPE.ENVCHANGE] = require('./env-change-token-parser')
-tokenParsers[TYPE.ERROR] = require('./infoerror-token-parser').errorParser
-tokenParsers[TYPE.INFO] = require('./infoerror-token-parser').infoParser
-tokenParsers[TYPE.LOGINACK] = require('./loginack-token-parser')
-tokenParsers[TYPE.ORDER] = require('./order-token-parser')
-tokenParsers[TYPE.RETURNSTATUS] = require('./returnstatus-token-parser')
-tokenParsers[TYPE.RETURNVALUE] = require('./returnvalue-token-parser')
-tokenParsers[TYPE.ROW] = require('./row-token-parser')
-tokenParsers[TYPE.NBCROW] = require('./nbcrow-token-parser')
-tokenParsers[TYPE.SSPI] = require('./sspi-token-parser')
+StreamParser = require("./stream-parser")
 
 ###
   Buffers are thrown at the parser (by calling addBuffer).
@@ -30,62 +13,16 @@ tokenParsers[TYPE.SSPI] = require('./sspi-token-parser')
 ###
 class Parser extends EventEmitter
   constructor: (@debug, @colMetadata, @options) ->
-    @buffer = new ReadableTrackingBuffer(new Buffer(0), 'ucs2')
-    @position = 0
+    @parser = new StreamParser(@debug, @colMetadata, @options)
+
+    @parser.on "data", (token) =>
+      if token.event
+        @emit(token.event, token)
 
   addBuffer: (buffer) ->
-    @buffer.add(buffer)
-    @position = @buffer.position
+    @parser.write(buffer)
 
-    while @nextToken()
-      'NOOP'
-
-    # Position to the end of the last successfully parsed token.
-    @buffer.position = @position
-
-  isEnd: ->
-    @buffer.empty()
-
-  nextToken: ->
-    try
-      # check if we have available bytes
-      unless @buffer.buffer.length > @buffer.position
-        return false
-
-      type = @buffer.readUInt8()
-
-      if tokenParsers[type]
-        token = tokenParsers[type](@buffer, @colMetadata, @options)
-
-        if token
-          @debug.token(token)
-
-          # Note current position, so that it can be rolled back to if the next token runs out of buffer.
-          @position = @buffer.position
-
-          if token.event
-            @emit(token.event, token)
-
-          switch token.name
-            when 'COLMETADATA'
-              @colMetadata = token.columns
-
-          return true
-        else
-          return false
-
-      else
-        @emit 'tokenStreamError', "Unrecognized token #{type} at offset #{@buffer.position}"
-        return false
-
-    catch error
-      if error?.code == 'oob'
-        #console.error "OOB ERROR", type, error.stack
-        # There was an attempt to read past the end of the buffer.
-        # In other words, we've run out of buffer.
-        return false
-      else
-        @emit 'tokenStreamError', error
-        return false
+  isEnd: () ->
+    @parser.buffer.length == 0
 
 exports.Parser = Parser

--- a/src/value-parser.coffee
+++ b/src/value-parser.coffee
@@ -1,7 +1,8 @@
 iconv = require('iconv-lite')
 sprintf = require('sprintf').sprintf
 guidParser = require('./guid-parser')
-require('./buffertools')
+
+convertLEBytesToString = require('./tracking-buffer/bigint').convertLEBytesToString
 
 NULL = (1 << 16) - 1
 MAX = (1 << 16) - 1
@@ -13,7 +14,7 @@ UNKNOWN_PLP_LEN = new Buffer([0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
 
 DEFAULT_ENCODING = 'utf8'
 
-parse = (buffer, metaData, options) ->
+module.exports = (parser, metaData, options) ->
   value = undefined
   dataLength = undefined
   textPointerNull = undefined
@@ -22,10 +23,10 @@ parse = (buffer, metaData, options) ->
 
   if type.hasTextPointerAndTimestamp
     # Appear to be dummy values, so consume and discard them.
-    textPointerLength = buffer.readUInt8()
+    textPointerLength = (yield parser.readUInt8())
     if textPointerLength != 0
-      buffer.readBuffer(textPointerLength)
-      buffer.readBuffer(8)
+      yield parser.readBuffer(textPointerLength)
+      yield parser.readBuffer(8)
     else
       dataLength = 0
       textPointerNull = true
@@ -43,11 +44,11 @@ parse = (buffer, metaData, options) ->
             when 0
               dataLength = undefined
             when 1
-              dataLength = buffer.readUInt8()
+              dataLength = yield parser.readUInt8()
             when 2
-              dataLength = buffer.readUInt16LE()
+              dataLength = yield parser.readUInt16LE()
             when 4
-              dataLength = buffer.readUInt32LE()
+              dataLength = yield parser.readUInt32LE()
             else
               throw Error("Unsupported dataLengthLength #{type.dataLengthLength} for data type #{type.name}")
       when 0x30 # xx11xxxx - s2.2.4.2.1.2
@@ -58,39 +59,39 @@ parse = (buffer, metaData, options) ->
     when 'Null'
       value = null
     when 'TinyInt'
-      value = buffer.readUInt8()
+      value = yield parser.readUInt8()
     when 'Int'
-      value = buffer.readInt32LE()
+      value = yield parser.readInt32LE()
     when 'SmallInt'
-      value = buffer.readInt16LE()
+      value = yield parser.readInt16LE()
     when 'BigInt'
-      value = buffer.readAsStringInt64LE()
+      value = convertLEBytesToString(yield parser.readBuffer(8))
     when 'IntN'
       switch dataLength
         when 0
           value = null
         when 1
-          value = buffer.readUInt8()
+          value = yield parser.readUInt8()
         when 2
-          value = buffer.readInt16LE()
+          value = yield parser.readInt16LE()
         when 4
-          value = buffer.readInt32LE()
+          value = yield parser.readInt32LE()
         when 8
-          value = buffer.readAsStringInt64LE()
+          value = convertLEBytesToString(yield parser.readBuffer(8))
         else
           throw new Error("Unsupported dataLength #{dataLength} for IntN")
     when 'Real'
-      value = buffer.readFloatLE()
+      value = yield parser.readFloatLE()
     when 'Float'
-      value = buffer.readDoubleLE()
+      value = yield parser.readDoubleLE()
     when 'FloatN'
       switch dataLength
         when 0
           value = null
         when 4
-          value = buffer.readFloatLE()
+          value = yield parser.readFloatLE()
         when 8
-          value = buffer.readDoubleLE()
+          value = yield parser.readDoubleLE()
         else
           throw new Error("Unsupported dataLength #{dataLength} for FloatN")
     when 'Money', 'SmallMoney', 'MoneyN'
@@ -98,102 +99,102 @@ parse = (buffer, metaData, options) ->
         when 0
           value = null
         when 4
-          value = buffer.readInt32LE() / MONEY_DIVISOR
+          value = (yield parser.readInt32LE()) / MONEY_DIVISOR
         when 8
-          high = buffer.readInt32LE()
-          low = buffer.readUInt32LE()
+          high = yield parser.readInt32LE()
+          low = yield parser.readUInt32LE()
           value = low + (0x100000000 * high)
           value /= MONEY_DIVISOR
         else
           throw new Error("Unsupported dataLength #{dataLength} for MoneyN")
     when 'Bit'
-      value = !!buffer.readUInt8()
+      value = !!(yield parser.readUInt8())
     when 'BitN'
       switch dataLength
         when 0
           value = null
         when 1
-          value = !!buffer.readUInt8()
+          value = !!(yield parser.readUInt8())
     when 'VarChar', 'Char'
       codepage = metaData.collation.codepage
       if metaData.dataLength == MAX
-        value = readMaxChars(buffer, codepage)
+        value = yield from readMaxChars(parser, codepage)
       else
-        value = readChars(buffer, dataLength, codepage)
+        value = yield from readChars(parser, dataLength, codepage)
     when 'NVarChar', 'NChar'
       if metaData.dataLength == MAX
-        value = readMaxNChars(buffer)
+        value = yield from readMaxNChars(parser)
       else
-        value = readNChars(buffer, dataLength)
+        value = yield from readNChars(parser, dataLength)
     when 'VarBinary', 'Binary'
       if metaData.dataLength == MAX
-        value = readMaxBinary(buffer)
+        value = yield from readMaxBinary(parser)
       else
-        value = readBinary(buffer, dataLength)
+        value = yield from readBinary(parser, dataLength)
     when 'Text'
       if textPointerNull
         value = null
       else
-        value = readChars(buffer, dataLength, metaData.collation.codepage)
+        value = yield from readChars(parser, dataLength, metaData.collation.codepage)
     when 'NText'
       if textPointerNull
         value = null
       else
-        value = readNChars(buffer, dataLength)
+        value = yield from readNChars(parser, dataLength)
     when 'Image'
       if textPointerNull
         value = null
       else
-        value = readBinary(buffer, dataLength)
+        value = yield from readBinary(parser, dataLength)
     when 'Xml'
-      value = readMaxNChars(buffer)
+      value = yield from readMaxNChars(parser)
     when 'SmallDateTime'
-      value = readSmallDateTime(buffer, options.useUTC)
+      value = yield from readSmallDateTime(parser, options.useUTC)
     when 'DateTime'
-      value = readDateTime(buffer, options.useUTC)
+      value = yield from readDateTime(parser, options.useUTC)
     when 'DateTimeN'
       switch dataLength
         when 0
           value = null
         when 4
-          value = readSmallDateTime(buffer, options.useUTC)
+          value = yield from readSmallDateTime(parser, options.useUTC)
         when 8
-          value = readDateTime(buffer, options.useUTC)
+          value = yield from readDateTime(parser, options.useUTC)
     when 'TimeN'
-      if (dataLength = buffer.readUInt8()) == 0
+      if (dataLength = yield parser.readUInt8()) == 0
         value = null
       else
-        value = readTime buffer, dataLength, metaData.scale, options.useUTC
+        value = yield from readTime(parser, dataLength, metaData.scale, options.useUTC)
     when 'DateN'
-      if (dataLength = buffer.readUInt8()) == 0
+      if (dataLength = yield parser.readUInt8()) == 0
         value = null
       else
-        value = readDate buffer, options.useUTC
+        value = yield from readDate(parser, options.useUTC)
     when 'DateTime2N'
-      if (dataLength = buffer.readUInt8()) == 0
+      if (dataLength = yield parser.readUInt8()) == 0
         value = null
       else
-        value = readDateTime2 buffer, dataLength, metaData.scale, options.useUTC
+        value = yield from readDateTime2(parser, dataLength, metaData.scale, options.useUTC)
     when 'DateTimeOffsetN'
-      if (dataLength = buffer.readUInt8()) == 0
+      if (dataLength = yield parser.readUInt8()) == 0
         value = null
       else
-        value = readDateTimeOffset buffer, dataLength, metaData.scale
+        value = yield from readDateTimeOffset(parser, dataLength, metaData.scale)
     when 'NumericN', 'DecimalN'
       if dataLength == 0
         value = null
       else
-        sign = if buffer.readUInt8() == 1 then 1 else -1
+        sign = if (yield parser.readUInt8()) == 1 then 1 else -1
 
         switch dataLength - 1
           when 4
-            value = buffer.readUInt32LE()
+            value = yield parser.readUInt32LE()
           when 8
-            value = buffer.readUNumeric64LE()
+            value = yield from parser.readUNumeric64LE()
           when 12
-            value = buffer.readUNumeric96LE()
+            value = yield from parser.readUNumeric96LE()
           when 16
-            value = buffer.readUNumeric128LE()
+            value = yield from parser.readUNumeric128LE()
           else
             throw new Error(sprintf('Unsupported numeric size %d at offset 0x%04X', dataLength - 1, buffer.position))
             break
@@ -205,88 +206,91 @@ parse = (buffer, metaData, options) ->
         when 0
           value = null
         when 0x10
-          value = guidParser.arrayToGuid( buffer.readArray(0x10) )
+          data = new Buffer(yield parser.readBuffer(0x10))
+          value = guidParser.arrayToGuid(data)
         else
           throw new Error(sprintf('Unsupported guid size %d at offset 0x%04X', dataLength - 1, buffer.position))
     when 'UDT'
-      value = readMaxBinary(buffer)
+      value = yield from readMaxBinary(parser)
     else
       throw new Error(sprintf('Unrecognised type %s at offset 0x%04X', type.name, buffer.position))
       break
 
   value
 
-readBinary = (buffer, dataLength) ->
+readBinary = (parser, dataLength) ->
   if dataLength == NULL
     null
   else
-    buffer.readBuffer(dataLength)
+    yield parser.readBuffer(dataLength)
 
-readChars = (buffer, dataLength, codepage=DEFAULT_ENCODING) ->
+readChars = (parser, dataLength, codepage=DEFAULT_ENCODING) ->
   if dataLength == NULL
     null
   else
-    iconv.decode(buffer.readBuffer(dataLength), codepage)
+    iconv.decode(yield parser.readBuffer(dataLength), codepage)
 
-readNChars = (buffer, dataLength) ->
+readNChars = (parser, dataLength) ->
   if dataLength == NULL
     null
   else
-    buffer.readString(dataLength, 'ucs2')
+    (yield parser.readBuffer(dataLength)).toString("ucs2")
 
-readMaxBinary = (buffer) ->
-  readMax(buffer, (valueBuffer) ->
-    valueBuffer
-  )
+readMaxBinary = (parser) ->
+  yield from readMax(parser)
 
-readMaxChars = (buffer, codepage=DEFAULT_ENCODING) ->
-  readMax(buffer, (valueBuffer) ->
-    iconv.decode(valueBuffer, codepage)
-  )
-
-readMaxNChars = (buffer) ->
-  readMax(buffer, (valueBuffer) ->
-    valueBuffer.toString('ucs2')
-  )
-
-readMax = (buffer, decodeFunction) ->
-  type = buffer.readBuffer(8)
-  if (type.equals(PLP_NULL))
-    null
+readMaxChars = (parser, codepage=DEFAULT_ENCODING) ->
+  if data = yield from readMax(parser)
+    iconv.decode(data, codepage)
   else
-    if (type.equals(UNKNOWN_PLP_LEN))
-      expectedLength = undefined
-    else
-      buffer.rollback()
-      expectedLength = buffer.readUInt64LE()
+    null
 
-    length = 0
-    chunks = []
+readMaxNChars = (parser) ->
+  (yield from readMax(parser)).toString('ucs2')
 
-    # Read, and accumulate, chunks from buffer.
-    chunkLength = buffer.readUInt32LE()
-    while (chunkLength != 0)
-      length += chunkLength
-      chunks.push(buffer.readBuffer(chunkLength))
+readMax = (parser) ->
+  type = yield parser.readBuffer(8)
+  if type.equals(PLP_NULL)
+    null
+  else if type.equals(UNKNOWN_PLP_LEN)
+    yield from readMaxUnknownLength(parser)
+  else
+    low = type.readUInt32LE(0)
+    high = type.readUInt32LE(4)
 
-      chunkLength = buffer.readUInt32LE()
+    if (high >= (2 << (53 - 32)))
+      console.warn("Read UInt64LE > 53 bits : high=#{high}, low=#{low}")
 
-    if expectedLength
-      if length != expectedLength
-        throw new Error("Partially Length-prefixed Bytes unmatched lengths : expected #{expectedLength}, but got #{length} bytes")
+    expectedLength = low + (0x100000000 * high)
+    yield from readMaxKnownLength(parser, expectedLength)
 
-    # Assemble all of the chunks in to one Buffer.
-    valueBuffer = new Buffer(length)
-    position = 0
-    for chunk in chunks
-      chunk.copy(valueBuffer, position, 0)
-      position += chunk.length
+readMaxKnownLength = (parser, totalLength) ->
+  data = new Buffer(totalLength)
 
-    decodeFunction(valueBuffer)
+  offset = 0
+  while (chunkLength = yield parser.readUInt32LE())
+    (yield parser.readBuffer(chunkLength)).copy(data, offset)
+    offset += chunkLength
 
-readSmallDateTime = (buffer, useUTC) ->
-  days = buffer.readUInt16LE()
-  minutes = buffer.readUInt16LE()
+  if offset != totalLength
+    throw new Error("Partially Length-prefixed Bytes unmatched lengths : expected #{totalLength}, but got #{offset} bytes")
+
+  data
+
+readMaxUnknownLength = (parser) ->
+  length = 0
+  chunks = []
+
+  while (chunkLength = yield parser.readUInt32LE())
+    length += chunkLength
+    chunks.push(yield parser.readBuffer(chunkLength))
+
+  # Assemble all of the chunks in to one Buffer.
+  Buffer.concat(chunks, length)
+
+readSmallDateTime = (parser, useUTC) ->
+  days = yield parser.readUInt16LE()
+  minutes = yield parser.readUInt16LE()
 
   if useUTC
     value = new Date(Date.UTC(1900, 0, 1))
@@ -296,12 +300,12 @@ readSmallDateTime = (buffer, useUTC) ->
     value = new Date(1900, 0, 1)
     value.setDate(value.getDate() + days)
     value.setMinutes(value.getMinutes() + minutes)
-    
+
   value
 
-readDateTime = (buffer, useUTC) ->
-  days = buffer.readInt32LE()
-  threeHundredthsOfSecond = buffer.readUInt32LE()
+readDateTime = (parser, useUTC) ->
+  days = yield parser.readInt32LE()
+  threeHundredthsOfSecond = yield parser.readUInt32LE()
   milliseconds = threeHundredthsOfSecond * THREE_AND_A_THIRD
 
   if useUTC
@@ -312,62 +316,60 @@ readDateTime = (buffer, useUTC) ->
     value = new Date(1900, 0, 1)
     value.setDate(value.getDate() + days)
     value.setMilliseconds(value.getMilliseconds() + milliseconds)
-    
+
   value
 
-readTime = (buffer, dataLength, scale, useUTC) ->
+readTime = (parser, dataLength, scale, useUTC) ->
   switch dataLength
-    when 3 then value = buffer.readUInt24LE()
-    when 4 then value = buffer.readUInt32LE()
-    when 5 then value = buffer.readUInt40LE()
+    when 3 then value = yield from parser.readUInt24LE()
+    when 4 then value = yield parser.readUInt32LE()
+    when 5 then value = yield from parser.readUInt40LE()
 
   if scale < 7
 	  value *= 10 for i in [scale+1..7]
-  
+
   if useUTC
     date = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, value / 10000))
   else
     date = new Date(1970, 0, 1, 0, 0, 0, value / 10000)
-    
+
   Object.defineProperty date, "nanosecondsDelta",
     enumerable: false
     value: (value % 10000) / Math.pow(10, 7)
 
   date
 
-readDate = (buffer, useUTC) ->
-  days = buffer.readUInt24LE()
+readDate = (parser, useUTC) ->
+  days = yield from parser.readUInt24LE()
 
   if useUTC
     new Date(Date.UTC(2000, 0, days - 730118))
   else
     new Date(2000, 0, days - 730118)
 
-readDateTime2 = (buffer, dataLength, scale, useUTC) ->
-  time = readTime buffer, dataLength - 3, scale, useUTC
-  days = buffer.readUInt24LE()
+readDateTime2 = (parser, dataLength, scale, useUTC) ->
+  time = yield from readTime(parser, dataLength - 3, scale, useUTC)
+  days = yield from parser.readUInt24LE()
 
   if useUTC
     date = new Date(Date.UTC(2000, 0, days - 730118, 0, 0, 0, +time))
   else
     date = new Date(2000, 0, days - 730118, time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds())
-    
+
   Object.defineProperty date, "nanosecondsDelta",
     enumerable: false
     value: time.nanosecondsDelta
-    
+
   date
 
-readDateTimeOffset = (buffer, dataLength, scale) ->
-  time = readTime buffer, dataLength - 5, scale, true
-  days = buffer.readUInt24LE()
-  offset = buffer.readInt16LE()
-  
+readDateTimeOffset = (parser, dataLength, scale) ->
+  time = yield from readTime(parser, dataLength - 5, scale, true)
+  days = yield from parser.readUInt24LE()
+  offset = yield parser.readInt16LE()
+
   date = new Date(Date.UTC(2000, 0, days - 730118, 0, 0, 0, +time))
   Object.defineProperty date, "nanosecondsDelta",
     enumerable: false
     value: time.nanosecondsDelta
-    
-  date
 
-module.exports = parse
+  date

--- a/test/register-coffee.js
+++ b/test/register-coffee.js
@@ -1,1 +1,20 @@
-require('coffee-script/register');
+"use strict";
+
+// Are we running on iojs?
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) >= 1) {
+  require('coffee-script/register');
+} else {
+  var CoffeeScript = require('coffee-script');
+  var babel = require("babel");
+
+  require.extensions[".coffee"] = function(module, filename) {
+    var answer = CoffeeScript._compileFile(filename, false);
+    var result = babel.transform(answer, {
+      filename: filename,
+      sourceMap: "both",
+      ast:       false
+    });
+
+    return module._compile(result.code, filename);
+  };
+}

--- a/test/unit/token/colmetadata-token-parser-test.coffee
+++ b/test/unit/token/colmetadata-token-parser-test.coffee
@@ -1,7 +1,8 @@
 parser = require('../../../src/token/colmetadata-token-parser')
 dataTypeByName = require('../../../src/data-type').typeByName
-ReadableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').ReadableTrackingBuffer
 WritableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
+
+TokenStreamParser = require('../../../src/token/stream-parser')
 
 module.exports.int = (test) ->
   numberOfColumns = 1
@@ -11,6 +12,7 @@ module.exports.int = (test) ->
 
   buffer = new WritableTrackingBuffer(50, 'ucs2')
 
+  buffer.writeUInt8(0x81)
   buffer.writeUInt16LE(numberOfColumns)
   buffer.writeUInt32LE(userType)
   buffer.writeUInt16LE(flags)
@@ -18,7 +20,9 @@ module.exports.int = (test) ->
   buffer.writeBVarchar(columnName)
   #console.log(buffer.data)
 
-  token = parser(new ReadableTrackingBuffer(buffer.data, 'ucs2'), null, {})
+  parser = new TokenStreamParser({}, {}, {})
+  parser.write(buffer.data)
+  token = parser.read()
   #console.log(token)
 
   test.ok(!token.error)
@@ -40,6 +44,7 @@ module.exports.varchar = (test) ->
 
   buffer = new WritableTrackingBuffer(50, 'ucs2')
 
+  buffer.writeUInt8(0x81)
   buffer.writeUInt16LE(numberOfColumns)
   buffer.writeUInt32LE(userType)
   buffer.writeUInt16LE(flags)
@@ -49,7 +54,9 @@ module.exports.varchar = (test) ->
   buffer.writeBVarchar(columnName)
   #console.log(buffer)
 
-  token = parser(new ReadableTrackingBuffer(buffer.data, 'ucs2'), null, {})
+  parser = new TokenStreamParser({}, {}, {})
+  parser.write(buffer.data)
+  token = parser.read()
   #console.log(token)
 
   test.ok(!token.error)

--- a/test/unit/token/done-token-parser-test.coffee
+++ b/test/unit/token/done-token-parser-test.coffee
@@ -1,5 +1,4 @@
-parser = require('../../../src/token/done-token-parser').doneParser
-ReadableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').ReadableTrackingBuffer
+Parser = require('../../../src/token/stream-parser')
 WritableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
 
 parse = (status, curCmd, doneRowCount) ->
@@ -8,15 +7,15 @@ parse = (status, curCmd, doneRowCount) ->
 
   buffer = new WritableTrackingBuffer(50, 'ucs2')
 
+  buffer.writeUInt8(0xFD)
   buffer.writeUInt16LE(status)
   buffer.writeUInt16LE(curCmd)
   buffer.writeUInt32LE(doneRowCountLow)
   buffer.writeUInt32LE(doneRowCountHi)
 
-  token = parser(new ReadableTrackingBuffer(buffer.data, 'ucs2'), null, {})
-  #console.log(token)
-  
-  token
+  parser = new Parser({}, {}, { tdsVersion: "7_2" })
+  parser.write(buffer.data)
+  parser.read()
 
 module.exports.done = (test) ->
   status = 0x0000

--- a/test/unit/token/infoerror-token-parser-test.coffee
+++ b/test/unit/token/infoerror-token-parser-test.coffee
@@ -1,5 +1,4 @@
-infoParser = require('../../../src/token/infoerror-token-parser').infoParser
-ReadableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').ReadableTrackingBuffer
+Parser = require('../../../src/token/stream-parser')
 WritableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
 
 module.exports.info = (test) ->
@@ -13,6 +12,7 @@ module.exports.info = (test) ->
 
   buffer = new WritableTrackingBuffer(50, 'ucs2')
 
+  buffer.writeUInt8(0xAB)
   buffer.writeUInt16LE(0)         # Length written later
   buffer.writeUInt32LE(number)
   buffer.writeUInt8(state)
@@ -23,11 +23,11 @@ module.exports.info = (test) ->
   buffer.writeUInt32LE(lineNumber)
 
   data = buffer.data
-  data.writeUInt16LE(data.length - 2, 0)
-  #console.log(buffer)
+  data.writeUInt16LE(data.length - 3, 1)
 
-  token = infoParser(new ReadableTrackingBuffer(data, 'ucs2'), null, {})
-  #console.log(token)
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(data)
+  token = parser.read()
 
   test.strictEqual(token.number, number)
   test.strictEqual(token.state, state)

--- a/test/unit/token/loginack-token-parser-test.coffee
+++ b/test/unit/token/loginack-token-parser-test.coffee
@@ -1,5 +1,4 @@
-parser = require('../../../src/token/loginack-token-parser')
-ReadableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').ReadableTrackingBuffer
+Parser = require('../../../src/token/stream-parser')
 WritableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
 
 module.exports.info = (test) ->
@@ -14,6 +13,7 @@ module.exports.info = (test) ->
 
   buffer = new WritableTrackingBuffer(50, 'ucs2')
 
+  buffer.writeUInt8(0xAD)
   buffer.writeUInt16LE(0)         # Length written later
   buffer.writeUInt8(interfaceType)
   buffer.writeUInt32BE(version)
@@ -24,11 +24,12 @@ module.exports.info = (test) ->
   buffer.writeUInt8(progVersion.buildNumLow)
 
   data = buffer.data
-  data.writeUInt16LE(data.length - 2, 0)
+  data.writeUInt16LE(data.length - 3, 1)
   #console.log(buffer)
 
-  token = parser(new ReadableTrackingBuffer(data, 'ucs2'))
-  #console.log(token)
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(data)
+  token = parser.read()
 
   test.strictEqual(token.interface, 'SQL_TSQL')
   test.strictEqual(token.tdsVersion, '7_2')

--- a/test/unit/token/order-token-parser-test.coffee
+++ b/test/unit/token/order-token-parser-test.coffee
@@ -1,6 +1,4 @@
-parser = require('../../../src/token/order-token-parser')
-dataTypeByName = require('../../../src/data-type').typeByName
-ReadableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').ReadableTrackingBuffer
+Parser = require('../../../src/token/stream-parser')
 WritableTrackingBuffer = require('../../../src/tracking-buffer/tracking-buffer').WritableTrackingBuffer
 
 module.exports.oneColumn = (test) ->
@@ -10,11 +8,14 @@ module.exports.oneColumn = (test) ->
 
   buffer = new WritableTrackingBuffer(50, 'ucs2')
 
+  buffer.writeUInt8(0xA9)
   buffer.writeUInt16LE(length)
   buffer.writeUInt16LE(column)
   #console.log(buffer.data)
 
-  token = parser(new ReadableTrackingBuffer(buffer.data, 'ucs2'))
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(buffer.data)
+  token = parser.read()
   #console.log(token)
 
   test.strictEqual(token.orderColumns.length, 1)
@@ -30,12 +31,15 @@ module.exports.twoColumns = (test) ->
 
   buffer = new WritableTrackingBuffer(50, 'ucs2')
 
+  buffer.writeUInt8(0xA9)
   buffer.writeUInt16LE(length)
   buffer.writeUInt16LE(column1)
   buffer.writeUInt16LE(column2)
   #console.log(buffer.data)
 
-  token = parser(new ReadableTrackingBuffer(buffer.data, 'ucs2'))
+  parser = new Parser({}, {}, { tdsVersion: '7_2' })
+  parser.write(buffer.data)
+  token = parser.read()
   #console.log(token)
 
   test.strictEqual(token.orderColumns.length, 2)


### PR DESCRIPTION
### TL;DR

Make Tedious fast and use less memory using the magic of generators.

### Stream Parser using Generators

This is an alternative to #225.

Instead of using the `dissolve` module to do the parsing, I'm using ES2015 Generators instead. This makes the code **a lot** more readable and the necessary changes to convert the existing code to stream parser **a lot** less intrusive (check the diff to see how "simple" the actual changes are).

As ES2015 Generators are only available by default with io.js, I'm using babel as an additional transpilation step to convert the generators to ES5 compatible code.

This introduces a few new runtime dependencies (`babel-runtime`, `bl` and `readable-stream`) and a new development dependency (`babel`).

---

Benchmarks:

Transpiled generators are generally fast. Here's a benchmark from running the code that is generated by compiling the coffeescript code into JS and transpiling that using babel:

```
$ node node_modules/coffee-script/bin/coffee benchmarks/query.coffee
Benchmarking 'nvarchar (small)'
nvarchar (small) x 71.71 ops/sec ±0.89% (36 runs sampled)
Memory: 3.5
Benchmarking 'nvarchar (large)'
nvarchar (large) x 9.86 ops/sec ±1.94% (49 runs sampled)
Memory: 21.16015625
Benchmarking 'varbinary (small)'
varbinary (small) x 66.51 ops/sec ±0.23% (15 runs sampled)
Memory: 6.5234375
Benchmarking 'varbinary (4)'
varbinary (4) x 66.66 ops/sec ±0.28% (16 runs sampled)
Memory: 2.59375
Benchmarking 'varbinary (large)'
varbinary (large) x 22.08 ops/sec ±2.33% (53 runs sampled)
Memory: 47.87109375
Benchmarking 'varbinary (huge)'
varbinary (huge) x 2.58 ops/sec ±1.47% (17 runs sampled)
Memory: 60.8828125
Done!
```

This is faster than the change that I proposed in #225, while being less intrusive and a lot easier to maintain in the long term.

---

Regarding the inclusion of `babel`: I'd love to convert Tedious from CoffeeScript to ES2015. CoffeeScript was a welcome improvement over plain old javascript, but nowadays we have ES2015 giving us most of the sugar that CoffeeScript provided while being natively supported by io.js (and it's easily transpiled using `babel` for older Node.JS versions).

This is something that we maintainers probably need to discuss seperately from this issue.

---

Any thoughts?