### PR TITLE
Release 1.11.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ deploy:
   provider: npm
   email: "schreiber.arthur@googlemail.com"
   api_key:
-    secure: bsf8+yRHbphPCaP6w0Fqg66zOEyBss/XGpKqSiESrBI4cbIPAKKvUL/SFzibKqRV6mtYYJGmwRSaS4okhwSeCvi0hnHqAMBQQs863eatoUNbTTrGfH5EB97jaqkcdpCCvtup2Uqu+GcHXRgW1HsQ51jAntfY5DAazVsuRCTNNHI=
+    secure: qqKBWeZEc5jvGuM8j44sgPNxqkrLaveRt1SIRqFZG9JRcA0i/t/vxRxhGSelnDymjzfQ4M71jAHQe9DJ14rjzMeFdA7qPUXfHjgmhQ4EQW3zBhVzAA2JxBZeoA2R6dcGkY6jsStjPQPBpTsUkFprDG96pHndB3mK4DJ+a6cs8ew=
   on:
     tags: true
+    repo: pekim/tedious
     node: "0.10"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/pekim/tedious",
   "bugs": "https://github.com/pekim/tedious/issues",
   "license": "MIT",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "main": "./lib/tedious.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
npmjs.com recently changed the API Key format, which caused the automatic release for 1.11.3 to fail (see #286).

Let's do another release that's identical with 1.11.3, hopefully working this time.