### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel": "^5.8.19",
     "benchmark": "^1.0.0",
     "coffee-script": "^1.9.3",
-    "nodeunit": "0.9.0"
+    "nodeunit": "^0.9.1"
   },
   "scripts": {
     "test": "nodeunit --reporter minimal test/register-coffee.js test/unit/ test/unit/token/ test/unit/tracking-buffer",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "async": "0.9.0",
-    "babel": "^5.8.12",
+    "babel": "^5.8.19",
     "benchmark": "^1.0.0",
     "coffee-script": "1.9.0",
     "nodeunit": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-runtime": "^5.8.19",
     "big-number": "0.3.1",
     "bl": "^1.0.0",
-    "iconv-lite": "0.4.7",
+    "iconv-lite": "^0.4.11",
     "readable-stream": "^2.0.2",
     "sprintf": "0.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "async": "^1.4.0",
     "babel": "^5.8.19",
     "benchmark": "^1.0.0",
-    "coffee-script": "1.9.0",
+    "coffee-script": "^1.9.3",
     "nodeunit": "0.9.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sprintf": "0.1.5"
   },
   "devDependencies": {
-    "async": "0.9.0",
+    "async": "^1.4.0",
     "babel": "^5.8.19",
     "benchmark": "^1.0.0",
     "coffee-script": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">= 0.10"
   },
   "dependencies": {
-    "babel-runtime": "^5.8.12",
+    "babel-runtime": "^5.8.19",
     "big-number": "0.3.1",
     "bl": "^1.0.0",
     "iconv-lite": "0.4.7",


### PR DESCRIPTION
This upgrades all our dependencies to their latest versions.

Most of these upgrades are to ensure we run on the latest versions, except for the `coffee-script` upgrade, which fixes an important bug.

* `babel@5.8.19` and `babel-runtime@5.8.19`
* `async@1.4.0`
* `iconv-lite@0.4.11`
* `coffee-script@1.9.3`
* `node-unit@0.9.1`