### PR TITLE
CI config changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ node_js:
   - "2.0"
   - "2.3"
 
+cache:
+  directories:
+    - node_modules
+
 deploy:
   provider: npm
   skip_cleanup: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
 
+cache:
+  - node_modules
+
 build: off
 
 before_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,11 @@ version: "{build}"
 environment:
   matrix:
     - nodejs_version: "0.10"
-    - nodejs_version: "0.11"
-    - nodejs_version: "1.1.0"
+    - nodejs_version: "0.12"
+    - nodejs_version: "1.0"
+    - nodejs_version: "1.8"
+    - nodejs_version: "2.0"
+    - nodejs_version: "2.3"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
This changes the CI configs for AppVeyor and Travis to run builds with the same Node.JS / iojs versions. It also adds caching for the `node_modules` folder, to speed up the builds.

On Travis, this reduces the total build time by ~30 seconds, while I'm not so sure whether caching has any impact on the AppVeyor build.