### PR TITLE
Release 1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/pekim/tedious",
   "bugs": "https://github.com/pekim/tedious/issues",
   "license": "MIT",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "main": "./lib/tedious.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* #297 Fix #295 (Windows Domain Authentication no longer working). This issue was accidentally introduced by #285.