### PR TITLE
Don't overwrite configuration with routing data.

### DIFF
--- a/src/connection.coffee
+++ b/src/connection.coffee
@@ -82,8 +82,6 @@ class Connection extends EventEmitter
         connectTimeout: ->
           @transitionTo(@STATE.FINAL)
         reconnect: ->
-          @config.server = @routingData.server
-          @config.options.port = @routingData.port
           @transitionTo(@STATE.CONNECTING)
 
     SENT_TLSSSLNEGOTIATION:
@@ -486,8 +484,12 @@ class Connection extends EventEmitter
     @socket = new Socket({})
 
     connectOpts =
-      host: @config.server
-      port: port
+      host: @routingData?.server || @config.server
+      port: @routingData?.port || port
+
+    # Unset routing information so we reuse the initial config on the next
+    # connection attempt again.
+    @routingData = undefined
 
     if @config.options.localAddress
       connectOpts.localAddress = @config.options.localAddress


### PR DESCRIPTION
This fixes #262, #307 and #269. I also believe it fixes #258.

It's a bit simpler than the fix proposed in #269, and passes all unit and integration tests.

I can push a beta package to npm with this fix in place, if anyone is interested in testing this. I'll release `1.11.5` including this fix and I'll port the fix to 1.12 and the `master` branch once someone confirms this is working for them.

//cc @gleeds @bretcope @tysjiang @SyRenity @spanditcaa PTAL