### PR TITLE
Remove use of generator functions

### DIFF
--- a/src/token/done-token-parser.js
+++ b/src/token/done-token-parser.js
@@ -10,52 +10,51 @@ const STATUS = {
   SRVERROR: 0x0100
 };
 
-function* parseToken(parser, options) {
-  const status = yield parser.readUInt16LE();
-  const more = !!(status & STATUS.MORE);
-  const sqlError = !!(status & STATUS.ERROR);
-  const rowCountValid = !!(status & STATUS.COUNT);
-  const attention = !!(status & STATUS.ATTN);
-  const serverError = !!(status & STATUS.SRVERROR);
-  const curCmd = yield parser.readUInt16LE();
+function parseToken(parser, options, callback) {
+  parser.readUInt16LE((status) => {
+    const more = !!(status & STATUS.MORE);
+    const sqlError = !!(status & STATUS.ERROR);
+    const rowCountValid = !!(status & STATUS.COUNT);
+    const attention = !!(status & STATUS.ATTN);
+    const serverError = !!(status & STATUS.SRVERROR);
 
-  let rowCount;
-  // If rowCount > 53 bits then rowCount will be incorrect (because Javascript uses IEEE_754 for number representation).
-  if (options.tdsVersion < "7_2") {
-    rowCount = yield parser.readUInt32LE();
-  } else {
-    rowCount = yield parser.readUInt64LE();
-  }
-
-  return {
-    name: 'DONE',
-    event: 'done',
-    more: more,
-    sqlError: sqlError,
-    attention: attention,
-    serverError: serverError,
-    rowCount: rowCountValid ? rowCount : undefined,
-    curCmd: curCmd
-  };
+    parser.readUInt16LE((curCmd) => {
+      (options.tdsVersion < "7_2" ? parser.readUInt32LE : parser.readUInt64LE).call(parser, (rowCount) => {
+        callback({
+          name: 'DONE',
+          event: 'done',
+          more: more,
+          sqlError: sqlError,
+          attention: attention,
+          serverError: serverError,
+          rowCount: rowCountValid ? rowCount : undefined,
+          curCmd: curCmd
+        });
+      });
+    });
+  });
 }
 
-export function* doneParser(parser, colMetadata, options) {
-  const token = yield* parseToken(parser, options);
-  token.name = 'DONE';
-  token.event = 'done';
-  return token;
+export function doneParser(parser, colMetadata, options, callback) {
+  parseToken(parser, options, (token) => {
+    token.name = 'DONE';
+    token.event = 'done';
+    callback(token);
+  });
 }
 
-export function* doneInProcParser(parser, colMetadata, options) {
-  const token = yield* parseToken(parser, options);
-  token.name = 'DONEINPROC';
-  token.event = 'doneInProc';
-  return token;
+export function doneInProcParser(parser, colMetadata, options, callback) {
+  parseToken(parser, options, (token) => {
+    token.name = 'DONEINPROC';
+    token.event = 'doneInProc';
+    callback(token);
+  });
 }
 
-export function* doneProcParser(parser, colMetadata, options) {
-  const token = yield* parseToken(parser, options);
-  token.name = 'DONEPROC';
-  token.event = 'doneProc';
-  return token;
+export function doneProcParser(parser, colMetadata, options, callback) {
+  parseToken(parser, options, (token) => {
+    token.name = 'DONEPROC';
+    token.event = 'doneProc';
+    callback(token);
+  });
 }

--- a/src/token/infoerror-token-parser.js
+++ b/src/token/infoerror-token-parser.js
@@ -1,40 +1,44 @@
-function* parseToken(parser, options) {
-  yield parser.readUInt16LE(); // length
-  const number = yield parser.readUInt32LE();
-  const state = yield parser.readUInt8();
-  const clazz = yield parser.readUInt8();
-  const message = yield* parser.readUsVarChar();
-  const serverName = yield* parser.readBVarChar();
-  const procName = yield* parser.readBVarChar();
-
-  let lineNumber;
-  if (options.tdsVersion < '7_2') {
-    lineNumber = yield parser.readUInt16LE();
-  } else {
-    lineNumber = yield parser.readUInt32LE();
-  }
-
-  return {
-    number: number,
-    state: state,
-    "class": clazz,
-    message: message,
-    serverName: serverName,
-    procName: procName,
-    lineNumber: lineNumber
-  };
+function parseToken(parser, options, callback) {
+  // length
+  parser.readUInt16LE(() => {
+    parser.readUInt32LE((number) => {
+      parser.readUInt8((state) => {
+        parser.readUInt8((clazz) => {
+          parser.readUsVarChar((message) => {
+            parser.readBVarChar((serverName) => {
+              parser.readBVarChar((procName) => {
+                (options.tdsVersion < '7_2' ? parser.readUInt16LE : parser.readUInt32LE).call(parser, (lineNumber) => {
+                  callback({
+                    number: number,
+                    state: state,
+                    "class": clazz,
+                    message: message,
+                    serverName: serverName,
+                    procName: procName,
+                    lineNumber: lineNumber
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 }
 
-export function* infoParser(parser, colMetadata, options) {
-  const token = yield* parseToken(parser, options);
-  token.name = 'INFO';
-  token.event = 'infoMessage';
-  return token;
+export function infoParser(parser, colMetadata, options, callback) {
+  parseToken(parser, options, (token) => {
+    token.name = 'INFO';
+    token.event = 'infoMessage';
+    callback(token);
+  });
 }
 
-export function* errorParser(parser, colMetadata, options) {
-  const token = yield* parseToken(parser, options);
-  token.name = 'ERROR';
-  token.event = 'errorMessage';
-  return token;
+export function errorParser(parser, colMetadata, options, callback) {
+  parseToken(parser, options, (token) => {
+    token.name = 'ERROR';
+    token.event = 'errorMessage';
+    callback(token);
+  });
 }

--- a/src/token/loginack-token-parser.js
+++ b/src/token/loginack-token-parser.js
@@ -5,26 +5,37 @@ const interfaceTypes = {
   1: 'SQL_TSQL'
 };
 
-module.exports = function*(parser) {
-  yield parser.readUInt16LE(); // length
-  const interfaceNumber = yield parser.readUInt8();
-  const interfaceType = interfaceTypes[interfaceNumber];
-  const tdsVersionNumber = yield parser.readUInt32BE();
-  const tdsVersion = versions[tdsVersionNumber];
-  const progName = yield* parser.readBVarChar();
-  const progVersion = {
-    major: yield parser.readUInt8(),
-    minor: yield parser.readUInt8(),
-    buildNumHi: yield parser.readUInt8(),
-    buildNumLow: yield parser.readUInt8()
-  };
-
-  return {
-    name: 'LOGINACK',
-    event: 'loginack',
-    "interface": interfaceType,
-    tdsVersion: tdsVersion,
-    progName: progName,
-    progVersion: progVersion
-  };
+module.exports = function(parser, colMetadata, options, callback) {
+  // length
+  parser.readUInt16LE(() => {
+    parser.readUInt8((interfaceNumber) => {
+      const interfaceType = interfaceTypes[interfaceNumber];
+      parser.readUInt32BE((tdsVersionNumber) => {
+        const tdsVersion = versions[tdsVersionNumber];
+        parser.readBVarChar((progName) => {
+          parser.readUInt8((major) => {
+            parser.readUInt8((minor) => {
+              parser.readUInt8((buildNumHi) => {
+                parser.readUInt8((buildNumLow) => {
+                  callback({
+                    name: 'LOGINACK',
+                    event: 'loginack',
+                    "interface": interfaceType,
+                    tdsVersion: tdsVersion,
+                    progName: progName,
+                    progVersion: {
+                      major: major,
+                      minor: minor,
+                      buildNumHi: buildNumHi,
+                      buildNumLow: buildNumLow
+                    }
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
 };

--- a/src/token/order-token-parser.js
+++ b/src/token/order-token-parser.js
@@ -1,16 +1,31 @@
 // s2.2.7.14
 
-export default function*(parser) {
-  const columnCount = (yield parser.readUInt16LE("length")) / 2;
-  const orderColumns = [];
+export default function(parser, colMetadata, options, callback) {
+  parser.readUInt16LE((length) => {
+    const columnCount = length / 2;
+    const orderColumns = [];
 
-  for (let i = 0; i < columnCount; i++) {
-    orderColumns.push(yield parser.readUInt16LE());
-  }
+    let i = 0;
+    function next(done) {
+      if (i === columnCount) {
+        return done();
+      }
 
-  return {
-    name: 'ORDER',
-    event: 'order',
-    orderColumns: orderColumns
-  };
+      parser.readUInt16LE((column) => {
+        orderColumns.push(column);
+
+        i++;
+
+        next(done);
+      });
+    }
+
+    next(() => {
+      callback({
+        name: 'ORDER',
+        event: 'order',
+        orderColumns: orderColumns
+      });
+    });
+  });
 }

--- a/src/token/returnstatus-token-parser.js
+++ b/src/token/returnstatus-token-parser.js
@@ -1,11 +1,11 @@
 // s2.2.7.16
 
-export default function*(parser) {
-  const value = yield parser.readInt32LE();
-
-  return {
-    name: 'RETURNSTATUS',
-    event: 'returnStatus',
-    value: value
-  };
+export default function(parser, colMetadata, options, callback) {
+  parser.readInt32LE((value) => {
+    callback({
+      name: 'RETURNSTATUS',
+      event: 'returnStatus',
+      value: value
+    });
+  });
 }

--- a/src/token/row-token-parser.js
+++ b/src/token/row-token-parser.js
@@ -2,29 +2,44 @@
 
 import valueParse from '../value-parser';
 
-export default function*(parser, columnsMetaData, options) {
+export default function(parser, colMetadata, options, callback) {
   const columns = options.useColumnNames ? {} : [];
 
-  for (let i = 0, len = columnsMetaData.length; i < len; i++) {
-    const columnMetaData = columnsMetaData[i];
-    const value = yield* valueParse(parser, columnMetaData, options);
-    const column = {
-      value: value,
-      metadata: columnMetaData
-    };
+  const len = colMetadata.length;
+  let i = 0;
 
-    if (options.useColumnNames) {
-      if (columns[columnMetaData.colName] == null) {
-        columns[columnMetaData.colName] = column;
-      }
-    } else {
-      columns.push(column);
+  function next(done) {
+    if (i === len) {
+      return done();
     }
+
+
+    const columnMetaData = colMetadata[i];
+    valueParse(parser, columnMetaData, options, (value) => {
+      const column = {
+        value: value,
+        metadata: columnMetaData
+      };
+
+      if (options.useColumnNames) {
+        if (columns[columnMetaData.colName] == null) {
+          columns[columnMetaData.colName] = column;
+        }
+      } else {
+        columns.push(column);
+      }
+
+      i++;
+
+      next(done);
+    });
   }
 
-  return {
-    name: 'ROW',
-    event: 'row',
-    columns: columns
-  };
+  next(() => {
+    callback({
+      name: 'ROW',
+      event: 'row',
+      columns: columns
+    });
+  });
 }

--- a/src/token/sspi-token-parser.js
+++ b/src/token/sspi-token-parser.js
@@ -17,10 +17,12 @@ function parseChallenge(buffer) {
   return challenge;
 }
 
-export default function*(parser) {
-  return {
-    name: 'SSPICHALLENGE',
-    event: 'sspichallenge',
-    ntlmpacket: parseChallenge(yield* parser.readUsVarByte())
-  };
+export default function(parser, colMetadata, options, callback) {
+  parser.readUsVarByte((buffer) => {
+    callback({
+      name: 'SSPICHALLENGE',
+      event: 'sspichallenge',
+      ntlmpacket: parseChallenge(buffer)
+    });
+  });
 }

--- a/src/token/stream-parser.js
+++ b/src/token/stream-parser.js
@@ -1,11 +1,13 @@
-import StreamParser from "../stream-parser";
+import { Transform } from "readable-stream";
 import { TYPE } from "./token";
 
 const tokenParsers = {
   [TYPE.COLMETADATA]: require('./colmetadata-token-parser'),
+
   [TYPE.DONE]: require('./done-token-parser').doneParser,
   [TYPE.DONEINPROC]: require('./done-token-parser').doneInProcParser,
   [TYPE.DONEPROC]: require('./done-token-parser').doneProcParser,
+
   [TYPE.ENVCHANGE]: require('./env-change-token-parser'),
   [TYPE.ERROR]: require('./infoerror-token-parser').errorParser,
   [TYPE.INFO]: require('./infoerror-token-parser').infoParser,
@@ -18,92 +20,313 @@ const tokenParsers = {
   [TYPE.SSPI]: require('./sspi-token-parser')
 };
 
-export default class Parser extends StreamParser {
+export default class Parser extends Transform {
   constructor(debug, colMetadata, options) {
-    super();
+    super({ objectMode: true });
 
     this.debug = debug;
     this.colMetadata = colMetadata;
     this.options = options;
+
+    this.nextStep = undefined;
+    this.buffer = new Buffer(0);
+    this.position = 0;
   }
 
-  *parser() {
-    for (;;) {
-      const type = yield this.readUInt8();
-      if (tokenParsers[type]) {
-        const token = yield* tokenParsers[type](this, this.colMetadata, this.options);
-        if (token) {
-          this.debug.token(token);
+  _transform(input, encoding, done) {
+    if (this.position === this.buffer.length) {
+      this.buffer = input;
+    } else {
+      this.buffer = Buffer.concat([this.buffer.slice(this.position), input]);
+    }
+    this.position = 0;
 
-          switch (token.name) {
-            case 'COLMETADATA':
-              this.colMetadata = token.columns;
-          }
+    // This will be called once we need to wait for more data to
+    // become available
+    this.await = done;
 
-          this.push(token);
-        }
-      } else {
-        throw new Error("Token type " + type + " not implemented");
-      }
+    if (!this.next) {
+      // Start the parser
+      this.parseNextToken();
+    } else {
+      // Continue from the last location
+      this.next();
     }
   }
 
+  parseNextToken() {
+    this.readUInt8((type) => {
+      if (tokenParsers[type]) {
+        tokenParsers[type](this, this.colMetadata, this.options, (token) => {
+          if (token) {
+            switch (token.name) {
+              case 'COLMETADATA':
+                this.colMetadata = token.columns;
+            }
+
+            this.push(token);
+          }
+
+          this.parseNextToken();
+        });
+      } else {
+        this.emit('error', new Error("Unknown type: " + type));
+      }
+    });
+  }
+
+  awaitData(length, callback) {
+    if (this.position + length <= this.buffer.length) {
+      callback();
+    } else {
+      this.next = () => {
+        this.awaitData(length, callback);
+      };
+      this.await();
+    }
+  }
+
+  readInt8(callback) {
+    this.awaitData(1, () => {
+      const data = this.buffer.readInt8(this.position);
+      this.position += 1;
+      callback(data);
+    });
+  }
+
+  readUInt8(callback) {
+    this.awaitData(1, () => {
+      const data = this.buffer.readUInt8(this.position);
+      this.position += 1;
+      callback(data);
+    });
+  }
+
+  readInt16LE(callback) {
+    this.awaitData(2, () => {
+      const data = this.buffer.readInt16LE(this.position);
+      this.position += 2;
+      callback(data);
+    });
+  }
+
+  readInt16BE(callback) {
+    this.awaitData(2, () => {
+      const data = this.buffer.readInt16BE(this.position);
+      this.position += 2;
+      callback(data);
+    });
+  }
+
+  readUInt16LE(callback) {
+    this.awaitData(2, () => {
+      const data = this.buffer.readUInt16LE(this.position);
+      this.position += 2;
+      callback(data);
+    });
+  }
+
+  readUInt16BE(callback) {
+    this.awaitData(2, () => {
+      const data = this.buffer.readUInt16BE(this.position);
+      this.position += 2;
+      callback(data);
+    });
+  }
+
+  readInt32LE(callback) {
+    this.awaitData(4, () => {
+      const data = this.buffer.readInt32LE(this.position);
+      this.position += 4;
+      callback(data);
+    });
+  }
+
+  readInt32BE(callback) {
+    this.awaitData(4, () => {
+      const data = this.buffer.readInt32BE(this.position);
+      this.position += 4;
+      callback(data);
+    });
+  }
+
+  readUInt32LE(callback) {
+    this.awaitData(4, () => {
+      const data = this.buffer.readUInt32LE(this.position);
+      this.position += 4;
+      callback(data);
+    });
+  }
+
+  readUInt32BE(callback) {
+    this.awaitData(4, () => {
+      const data = this.buffer.readUInt32BE(this.position);
+      this.position += 4;
+      callback(data);
+    });
+  }
+
+  readInt64LE(callback) {
+    this.awaitData(8, () => {
+      const data = Math.pow(2, 32) * this.buffer.readInt32LE(this.position + 4) + (this.buffer[this.position + 4] & 0x80 === 0x80 ? 1 : -1) * this.buffer.readUInt32LE(this.position);
+      this.position += 8;
+      callback(data);
+    });
+  }
+
+  readInt64BE(callback) {
+    this.awaitData(8, () => {
+      const data = Math.pow(2, 32) * this.buffer.readInt32BE(this.position) + (this.buffer[this.position] & 0x80 === 0x80 ? 1 : -1) * this.buffer.readUInt32BE(this.position + 4);
+      this.position += 8;
+      callback(data);
+    });
+  }
+
+  readUInt64LE(callback) {
+    this.awaitData(8, () => {
+      const data = Math.pow(2, 32) * this.buffer.readUInt32LE(this.position + 4) + this.buffer.readUInt32LE(this.position);
+      this.position += 8;
+      callback(data);
+    });
+  }
+
+  readUInt64BE(callback) {
+    this.awaitData(8, () => {
+      const data = Math.pow(2, 32) * this.buffer.readUInt32BE(this.position) + this.buffer.readUInt32BE(this.position + 4);
+      this.position += 8;
+      callback(data);
+    });
+  }
+
+  readFloatLE(callback) {
+    this.awaitData(4, () => {
+      const data = this.buffer.readFloatLE(this.position);
+      this.position += 4;
+      callback(data);
+    });
+  }
+
+  readFloatBE(callback) {
+    this.awaitData(4, () => {
+      const data = this.buffer.readFloatBE(this.position);
+      this.position += 4;
+      callback(data);
+    });
+  }
+
+  readDoubleLE(callback) {
+    this.awaitData(8, () => {
+      const data = this.buffer.readDoubleLE(this.position);
+      this.position += 8;
+      callback(data);
+    });
+  }
+
+  readDoubleBE(callback) {
+    this.awaitData(8, () => {
+      const data = this.buffer.readDoubleBE(this.position);
+      this.position += 8;
+      callback(data);
+    });
+  }
+
+  readUInt24LE(callback) {
+    this.awaitData(3, () => {
+      const low = this.buffer.readUInt16LE(this.position);
+      const high = this.buffer.readUInt8(this.position + 2);
+
+      this.position += 3;
+
+      callback(low | (high << 16));
+    });
+  }
+
+  readUInt40LE(callback) {
+    this.awaitData(5, () => {
+      const low = this.buffer.readUInt32LE(this.position);
+      const high = this.buffer.readUInt8(this.position + 4);
+
+      this.position += 5;
+
+      callback((0x100000000 * high) + low);
+    });
+  }
+
+  readUNumeric64LE(callback) {
+    this.awaitData(8, () => {
+      const low = this.buffer.readUInt32LE(this.position);
+      const high = this.buffer.readUInt32LE(this.position + 4);
+
+      this.position += 8;
+
+      callback((0x100000000 * high) + low);
+    });
+  }
+
+  readUNumeric96LE(callback) {
+    this.awaitData(12, () => {
+      const dword1 = this.buffer.readUInt32LE(this.position);
+      const dword2 = this.buffer.readUInt32LE(this.position + 4);
+      const dword3 = this.buffer.readUInt32LE(this.position + 8);
+
+      this.position += 12;
+
+      callback(dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3));
+    });
+  }
+
+  readUNumeric128LE(callback) {
+    this.awaitData(16, () => {
+      const dword1 = this.buffer.readUInt32LE(this.position);
+      const dword2 = this.buffer.readUInt32LE(this.position + 4);
+      const dword3 = this.buffer.readUInt32LE(this.position + 8);
+      const dword4 = this.buffer.readUInt32LE(this.position + 12);
+
+      this.position += 16;
+
+      callback(dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3) + (0x100000000 * 0x100000000 * 0x100000000 * dword4));
+    });
+  }
+
+  // Variable length data
+
+  readBuffer(length, callback) {
+    this.awaitData(length, () => {
+      const data = this.buffer.slice(this.position, this.position + length);
+      this.position += length;
+      callback(data);
+    });
+  }
+
   // Read a Unicode String (BVARCHAR)
-  *readBVarChar() {
-    const length = yield this.readUInt8();
-    const data = yield this.readBuffer(length * 2);
-    return data.toString("ucs2");
+  readBVarChar(callback) {
+    this.readUInt8((length) => {
+      this.readBuffer(length * 2, (data) => {
+        callback(data.toString("ucs2"));
+      });
+    });
   }
 
   // Read a Unicode String (USVARCHAR)
-  *readUsVarChar() {
-    const length = yield this.readUInt16LE();
-    const data = yield this.readBuffer(length * 2);
-    return data.toString("ucs2");
+  readUsVarChar(callback) {
+    this.readUInt16LE((length) => {
+      this.readBuffer(length * 2, (data) => {
+        callback(data.toString("ucs2"));
+      });
+    });
   }
 
   // Read binary data (BVARBYTE)
-  *readBVarByte() {
-    const length = yield this.readUInt8();
-    return yield this.readBuffer(length);
+  readBVarByte(callback) {
+    this.readUInt8((length) => {
+      this.readBuffer(length, callback);
+    });
   }
 
   // Read binary data (USVARBYTE)
-  *readUsVarByte() {
-    const length = yield this.readUInt16LE();
-    return yield this.readBuffer(length);
-  }
-
-  *readUInt24LE() {
-    const low = yield this.readUInt16LE();
-    const high = yield this.readUInt8();
-    return low | (high << 16);
-  }
-
-  *readUInt40LE() {
-    const low = yield this.readUInt32LE();
-    const high = yield this.readUInt8();
-    return (0x100000000 * high) + low;
-  }
-
-  *readUNumeric64LE() {
-    const low = yield this.readUInt32LE();
-    const high = yield this.readUInt32LE();
-    return (0x100000000 * high) + low;
-  }
-
-  *readUNumeric96LE() {
-    const dword1 = yield this.readUInt32LE();
-    const dword2 = yield this.readUInt32LE();
-    const dword3 = yield this.readUInt32LE();
-    return dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3);
-  }
-
-  *readUNumeric128LE() {
-    const dword1 = yield this.readUInt32LE();
-    const dword2 = yield this.readUInt32LE();
-    const dword3 = yield this.readUInt32LE();
-    const dword4 = yield this.readUInt32LE();
-    return dword1 + (0x100000000 * dword2) + (0x100000000 * 0x100000000 * dword3) + (0x100000000 * 0x100000000 * 0x100000000 * dword4);
+  readUsVarByte(callback) {
+    this.readUInt16LE((length) => {
+      this.readBuffer(length, callback);
+    });
   }
 }

--- a/src/token/stream-parser.js
+++ b/src/token/stream-parser.js
@@ -31,6 +31,8 @@ export default class Parser extends Transform {
     this.nextStep = undefined;
     this.buffer = new Buffer(0);
     this.position = 0;
+    this.await = undefined;
+    this.next = undefined;
   }
 
   _transform(input, encoding, done) {

--- a/src/token/token-stream-parser.js
+++ b/src/token/token-stream-parser.js
@@ -32,6 +32,6 @@ export class Parser extends EventEmitter {
   }
 
   isEnd()  {
-    return this.parser.buffer.length === 0;
+    return this.parser.buffer.length === this.parser.position;
   }
 }


### PR DESCRIPTION
The switch to a generator based parser in #285 brought better performance and decreased memory usage with large column values, but significantly decreased performance when processing a large number of result rows containing small column values. See #303 for more information.

---

This PR replaces all use of generator functions with a callback based approach. It is definately less elegant, but also has a much better performance profile.

Here's the benchmarks so far:

```
$ node benchmarks/
Many result rows x 7.19 ops/sec ±1.40% (38 runs sampled)
Memory: 25.03125 MiB
inserting nvarchar(max) with 5242880 chars x 15.00 ops/sec ±1.60% (69 runs sampled)
Memory: 28.88671875 MiB
inserting nvarchar(max) with 4 chars x 70.06 ops/sec ±0.38% (29 runs sampled)
Memory: 7.65234375 MiB
inserting varbinary(4) with 4 bytes x 70.06 ops/sec ±0.41% (29 runs sampled)
Memory: 8.015625 MiB
inserting varbinary(max) with 50 MiB x 4.03 ops/sec ±3.67% (24 runs sampled)
Memory: 90.84765625 MiB
inserting varbinary(max) with 5 MiB x 34.24 ops/sec ±2.63% (57 runs sampled)
Memory: 37.046875 MiB
inserting varbinary(max) with 4 bytes x 70.09 ops/sec ±0.35% (29 runs sampled)
Memory: 7.9765625 MiB
```

compared to `tedious` 1.12.3:

```
$ node benchmarks
Many result rows x 1.09 ops/sec ±1.35% (10 runs sampled)
Memory: 13.9296875 MiB
inserting nvarchar(max) with 5242880 chars x 10.33 ops/sec ±2.11% (51 runs sampled)
Memory: 29.625 MiB
inserting nvarchar(max) with 4 chars x 72.84 ops/sec ±0.52% (40 runs sampled)
Memory: 8.08984375 MiB
inserting varbinary(4) with 4 bytes x 71.34 ops/sec ±0.30% (34 runs sampled)
Memory: 8.1015625 MiB
inserting varbinary(max) with 50 MiB x 2.57 ops/sec ±3.22% (17 runs sampled)
Memory: 97.53515625 MiB
inserting varbinary(max) with 5 MiB x 21.09 ops/sec ±2.60% (51 runs sampled)
Memory: 69.35546875 MiB
inserting varbinary(max) with 4 bytes x 72.04 ops/sec ±0.43% (37 runs sampled)
Memory: 7.890625 MiB
```

and `tedious` 1.11.5:

```
$ node benchmarks/
Many result rows x 18.17 ops/sec ±1.48% (60 runs sampled)
Memory: 23.84375 MiB
inserting nvarchar(max) with 5242880 chars x 1.79 ops/sec ±1.09% (13 runs sampled)
Memory: 29.3515625 MiB
inserting nvarchar(max) with 4 chars x 67.65 ops/sec ±0.32% (19 runs sampled)
Memory: 5.5 MiB
inserting varbinary(4) with 4 bytes x 67.80 ops/sec ±0.28% (21 runs sampled)
Memory: 5.77734375 MiB
inserting varbinary(max) with 50 MiB x 0.08 ops/sec ±0.94% (5 runs sampled)
Memory: 208.00390625 MiB
inserting varbinary(max) with 5 MiB x 6.77 ops/sec ±1.67% (36 runs sampled)
Memory: 133.6640625 MiB
inserting varbinary(max) with 4 bytes x 67.77 ops/sec ±0.32% (21 runs sampled)
Memory: 5.796875 MiB
```

As you can see, we're still not back to the old performance, but the difference is not as big as before. There's a lot more that can be done to improve the performance even further. Basic profiling shows that a lot of time is currently spent recompiling the same functions over and over again, and there's also quite a few functions which either are never optimized or get deoptimized.