### PR TITLE
call callback for request on socket error

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -1055,7 +1055,10 @@ Connection.prototype.STATE = {
   SENT_CLIENT_REQUEST: {
     name: 'SentClientRequest',
     events: {
-      socketError: function() {
+      socketError: function(err) {
+        const sqlRequest = this.request;
+        this.request = void 0;
+        sqlRequest.callback(err);
         return this.transitionTo(this.STATE.FINAL);
       },
       data: function(data) {

--- a/test/integration/socket-error-test.coffee
+++ b/test/integration/socket-error-test.coffee
@@ -1,0 +1,42 @@
+Connection = require('../../src/connection')
+Request = require('../../src/request')
+fs = require('fs')
+
+getConfig = ->
+  config = JSON.parse(fs.readFileSync(process.env.HOME + '/.tedious/test-connection.json', 'utf8')).config
+
+  config.options.debug =
+    packet: true
+    data: true
+    payload: true
+    token: false
+    log: true
+
+  config
+
+exports.socketError = (test) ->
+  config = getConfig()
+
+  connection = new Connection(config)
+
+  test.expect(3);
+
+  connection.on('connect', (err) ->
+    test.ifError(err)
+    
+    # create temporary table
+    request = new Request("WAITFOR 00:00:30", (err) ->
+      test.ok(~err.message.indexOf('socket error'))
+    )
+    connection.execSql(request)
+    connection.socket.emit('error', new Error('socket error'))
+  )
+
+  connection.on('end', (info) ->
+    test.done();
+  )
+
+  connection.on('error', (err) ->
+    test.ok(~err.message.indexOf('socket error'))
+  )
+ 


### PR DESCRIPTION
When a socket error occurs the request callback is never called.  This patch calls the request callback when the connection state is set to SENT_CLIENT_REQUEST.  A simple test has been added.  This patch probably needs more scrutiny and testing.

If you are using tedious-connection-pool this patch will not have any effect as discussed here:

https://github.com/pekim/tedious-connection-pool/issues/23