### PR TITLE
Run Travis and AppVeyor builds with Node 4, instead of iojs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ before_install:
 node_js:
   - "0.10"
   - "0.12"
-  - "1.0"
-  - "1.8"
-  - "2.0"
-  - "2.3"
+  - "4"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,7 @@ environment:
   matrix:
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
-    - nodejs_version: "1.0"
-    - nodejs_version: "1.8"
-    - nodejs_version: "2.0"
-    - nodejs_version: "2.3"
+    - nodejs_version: "4"
 
 branches:
   only:


### PR DESCRIPTION
Let's stop running CI builds on iojs and instead run them on the latest Node 4 release.