### PR TITLE
Fix issues with DateTime2 parameters

### DIFF
--- a/src/rpcrequest-payload.js
+++ b/src/rpcrequest-payload.js
@@ -72,7 +72,7 @@ export default class RpcRequestPayload {
       if (type.hasScale) {
         if (parameter.scale) {
           param.scale = parameter.scale;
-        } else if (type.resolvePrecision) {
+        } else if (type.resolveScale) {
           param.scale = type.resolveScale(parameter);
         }
       }

--- a/test/integration/parameterised-statements-test.coffee
+++ b/test/integration/parameterised-statements-test.coffee
@@ -188,6 +188,12 @@ exports.dateTime = (test) ->
 exports.dateTimeNull = (test) ->
   execSql(test, TYPES.DateTime, null)
 
+exports.dateTime2 = (test) ->
+  execSql(test, TYPES.DateTime2, new Date('December 4, 2011 10:04:23'))
+
+exports.dateTime2Null = (test) ->
+  execSql(test, TYPES.DateTime2, null)
+
 exports.outputBitTrue = (test) ->
   execSqlOutput(test, TYPES.Bit, true)
 


### PR DESCRIPTION
This fixes #335.

I accidentally introduced a typo when converting this part of the code from CoffeeScript to Javascript. Unfortunately, there were no test cases for the `DateTime2` parameter type, so the issue was not found through our automated test cases.

This fixes the typo and adds test cases to ensure we don't introduce a similar issue again.

//cc @pawelrychlik @sentient Can you take a look? If this looks good to you, I'll push a new release with this fix included.