### PR TITLE
Fix for nvarchar(max) columns on sql 2005

### DIFF
--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -377,7 +377,11 @@ function readMaxChars(parser, codepage, callback) {
 
 function readMaxNChars(parser, callback) {
   readMax(parser, (data) => {
-    callback(data.toString('ucs2'))
+    if (data) {
+      callback(data.toString('ucs2'));
+    } else {
+      callback(null);
+    }
   });
 }
 


### PR DESCRIPTION
When reading nvarchar max, ensure data is not falsey fixes nvarchar(max) columns on sql 2005

see https://github.com/pekim/tedious/issues/327

not sure why this doesn't fail on sql 2008+? Somehow data is never null even if db value is null?