### PR TITLE
Release 1.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/pekim/tedious",
   "bugs": "https://github.com/pekim/tedious/issues",
   "license": "MIT",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "main": "./lib/tedious.js",
   "repository": {
     "type": "git",

--- a/src/value-parser.js
+++ b/src/value-parser.js
@@ -377,7 +377,11 @@ function readMaxChars(parser, codepage, callback) {
 
 function readMaxNChars(parser, callback) {
   readMax(parser, (data) => {
-    callback(data.toString('ucs2'))
+    if (data) {
+      callback(data.toString('ucs2'));
+    } else {
+      callback(null);
+    }
   });
 }
 


### PR DESCRIPTION
Another small bugfix release for an issue introduced in 1.13.0.

### Detailed Changelog

#340 Fix handling of null values in `nvarchar(max)` columns.